### PR TITLE
authn: Fix allowed-audiences flag parsing

### DIFF
--- a/authn/config.go
+++ b/authn/config.go
@@ -10,10 +10,11 @@ type IDVerifierConfig struct {
 	AllowedAudiences []string `yaml:"allowedAudiences"`
 }
 
-func (c *IDVerifierConfig) RegisterFlags(prefix string, fs flag.FlagSet) {
+func (c *IDVerifierConfig) RegisterFlags(prefix string, fs *flag.FlagSet) {
 	fs.StringVar(&c.SigningKeyURL, prefix+".signing-keys-url", "", "URL to jwks endpoint")
 
-	var allowedAudiences string
-	fs.StringVar(&allowedAudiences, prefix+".allowed-audiences", "", "Specifies a comma-separated list of allowed audiences.")
-	c.AllowedAudiences = strings.Split(allowedAudiences, ",")
+	fs.Func(prefix+".allowed-audiences", "Specifies a comma-separated list of allowed audiences.", func(v string) error {
+		c.AllowedAudiences = strings.Split(v, ",")
+		return nil
+	})
 }

--- a/authn/config_test.go
+++ b/authn/config_test.go
@@ -1,0 +1,19 @@
+package authn
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIDVerifierConfig_RegisterFlags(t *testing.T) {
+	var cfg IDVerifierConfig
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.RegisterFlags("test", fs)
+
+	err := fs.Parse([]string{"-test.allowed-audiences", "a,b,c", "-test.signing-keys-url", "localhost"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c"}, cfg.AllowedAudiences)
+	require.Equal(t, "localhost", cfg.SigningKeyURL)
+}


### PR DESCRIPTION
This PR fixes the parsing of the `*.allowed-audiences` flag.