### PR TITLE
Client: Cache search results with default expiration time.

### DIFF
--- a/authz/client.go
+++ b/authz/client.go
@@ -31,7 +31,6 @@ var (
 )
 
 const (
-	defaultExp = 0
 	cacheExp   = 5 * time.Minute
 	searchPath = "/api/access-control/users/permissions/search"
 )
@@ -237,5 +236,5 @@ func (c *clientImpl) cacheValue(ctx context.Context, perms permissionsByID, key 
 	}
 
 	// Cache with default expiry
-	return c.cache.Set(ctx, key, buf.Bytes(), defaultExp)
+	return c.cache.Set(ctx, key, buf.Bytes(), cache.DefaultExpiration)
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -9,7 +9,10 @@ import (
 	gocache "github.com/patrickmn/go-cache"
 )
 
-const NoExpiration = cache.NoExpiration
+const (
+	NoExpiration      = cache.NoExpiration
+	DefaultExpiration = cache.DefaultExpiration
+)
 
 var (
 	ErrNotFound = errors.New("not found")


### PR DESCRIPTION
We cached items with a hard coded 5*minutes expiration time.
This PR use the cache default expiration time instead.
This is particularly useful when the cache is being overridden. 