### PR TITLE
Authn: Add common wrappers for identity and access tokens

### DIFF
--- a/authn/errors.go
+++ b/authn/errors.go
@@ -11,6 +11,7 @@ var (
 	// Private error we wrap all other exported errors with
 	errInvalidToken      = errors.New("invalid token")
 	ErrParseToken        = fmt.Errorf("%w: failed to parse as jwt token", errInvalidToken)
+	ErrInvalidTokenType  = fmt.Errorf("%w: invalid token type", errInvalidToken)
 	ErrInvalidSigningKey = fmt.Errorf("%w: unrecognized signing key", errInvalidToken)
 
 	ErrExpiredToken    = fmt.Errorf("%w: expired token", errInvalidToken)

--- a/authn/extractor_access.go
+++ b/authn/extractor_access.go
@@ -1,0 +1,67 @@
+package authn
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/grafana/authlib/cache"
+)
+
+const (
+	tenantPrefixOrg   = "org:"
+	tenantPrefixStack = "stack:"
+)
+
+type accessClaims struct {
+	jwt.Claims
+	Scopes      []string `json:"scopes"`
+	Permissions []string `json:"permissions"`
+}
+
+type AccessToken struct {
+	// TenantID is an prefixed tenant identitfier either `org:` or `stack:`.
+	TenantID string
+	// Access policy scopes
+	Scopes []string `json:"scopes"`
+	// Grafana roles
+	Permissions []string `json:"permissions"`
+}
+
+func NewAccessExtractor(cfg IDVerifierConfig) *AccessExtractor {
+	return &AccessExtractor{
+		v: NewVerifier[accessClaims](cfg),
+	}
+}
+
+func NewAccessExtractorWithCache(cfg IDVerifierConfig, cache cache.Cache) *AccessExtractor {
+	return &AccessExtractor{
+		v: newVerifierWithKeyService[accessClaims](cfg, newKeyServiceWithCache(cfg.SigningKeysURL, cache)),
+	}
+}
+
+type AccessExtractor struct {
+	v Verifier[accessClaims]
+}
+
+func (e *AccessExtractor) FromToken(ctx context.Context, token string) (*AccessToken, error) {
+	claims, err := e.v.Verify(ctx, token, TypeAccessToken)
+	if err != nil {
+		return nil, err
+	}
+
+	access := &AccessToken{
+		Scopes:      claims.Rest.Scopes,
+		Permissions: claims.Rest.Permissions,
+	}
+
+	for _, aud := range claims.Audience {
+		if strings.HasPrefix(aud, tenantPrefixOrg) || strings.HasPrefix(aud, tenantPrefixStack) {
+			access.TenantID = aud
+			break
+		}
+
+	}
+
+	return access, nil
+}

--- a/authn/extractor_identity.go
+++ b/authn/extractor_identity.go
@@ -1,0 +1,61 @@
+package authn
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/grafana/authlib/cache"
+)
+
+type Identity struct {
+	// ID is an prefixed identifier for identity such as `user:` or `service-account:`.
+	ID string
+	// TenantID is an prefixed tenant identitfier either `org:` or `stack:`.
+	TenantID string
+	// AuthenticatedBy is the method used to authenticate the identity.
+	AuthenticatedBy string
+}
+
+type identityClaims struct {
+	jwt.Claims
+	AuthenticatedBy string
+}
+
+func NewIdentityExtractor(cfg IDVerifierConfig) *IdentityExtractor {
+	return &IdentityExtractor{
+		v: NewVerifier[identityClaims](cfg),
+	}
+}
+
+func NewIdentityExtractorWithCache(cfg IDVerifierConfig, cache cache.Cache) *IdentityExtractor {
+	return &IdentityExtractor{
+		v: newVerifierWithKeyService[identityClaims](cfg, newKeyServiceWithCache(cfg.SigningKeysURL, cache)),
+	}
+}
+
+type IdentityExtractor struct {
+	v Verifier[identityClaims]
+}
+
+func (e *IdentityExtractor) FromToken(ctx context.Context, token string) (*Identity, error) {
+	claims, err := e.v.Verify(ctx, token, TypeIDToken)
+	if err != nil {
+		return nil, err
+	}
+
+	identity := &Identity{
+		ID:              claims.Subject,
+		AuthenticatedBy: claims.Rest.AuthenticatedBy,
+	}
+
+	for _, aud := range claims.Audience {
+		if strings.HasPrefix(aud, tenantPrefixOrg) || strings.HasPrefix(aud, tenantPrefixStack) {
+			identity.TenantID = aud
+			break
+		}
+
+	}
+
+	return identity, nil
+}

--- a/authn/jwks.go
+++ b/authn/jwks.go
@@ -73,7 +73,7 @@ func (s *keyService) Get(ctx context.Context, keyID string) (*jose.JSONWebKey, e
 }
 
 func (s *keyService) fetchJWKS(ctx context.Context) (*jose.JSONWebKeySet, error) {
-	req, err := http.NewRequest("GET", s.url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", s.url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/authn/jwks.go
+++ b/authn/jwks.go
@@ -20,13 +20,18 @@ const (
 )
 
 func newKeyService(jwksURL string) *keyService {
+	return newKeyServiceWithCache(jwksURL, cache.NewLocalCache(cache.Config{
+		Expiry:          cacheTTL,
+		CleanupInterval: cacheCleanupInterval,
+	}))
+
+}
+
+func newKeyServiceWithCache(jwksURL string, cache cache.Cache) *keyService {
 	return &keyService{
 		url: jwksURL,
-		c: cache.NewLocalCache(cache.Config{
-			Expiry:          cacheTTL,
-			CleanupInterval: cacheCleanupInterval,
-		}),
-		s: &singleflight.Group{},
+		c:   cache,
+		s:   &singleflight.Group{},
 	}
 }
 


### PR DESCRIPTION
This add two wrappers around verifier with common use-cases we have.

One wrapper for extrating and validating grafana id tokens and one for access tokens. I also break the api on verify to include the expected typ of the token. We use `at+jwt` for access tokens and `jwt` for id tokens.