### PR TITLE
Fix: sync claims and update function name

### DIFF
--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -8,7 +8,9 @@ import (
 
 type IDTokenClaims struct {
 	// AuthenticatedBy is the method used to authenticate the identity.
-	AuthenticatedBy string
+	AuthenticatedBy string `json:"authenticatedBy"`
+	Email           string `json:"email"`
+	EmailVerified   string `json:"email_verified"`
 }
 
 func NewIDTokenVerifier(cfg VerifierConfig) *IDTokenVerifier {
@@ -29,6 +31,6 @@ type IDTokenVerifier struct {
 	v Verifier[IDTokenClaims]
 }
 
-func (e *IDTokenVerifier) FromToken(ctx context.Context, token string) (*Claims[IDTokenClaims], error) {
+func (e *IDTokenVerifier) Verify(ctx context.Context, token string) (*Claims[IDTokenClaims], error) {
 	return e.v.Verify(ctx, token)
 }


### PR DESCRIPTION
Sync claims from https://github.com/grafana/grafana/blob/651223fe2d69536b3576080a8ea3e6156136bc28/pkg/services/auth/id.go#L23-L28 and update function name to align with `Verifier` and `AccessTokenVerifier`.