### PR TITLE
ExchangeClient: fix spelling, provide interface

### DIFF
--- a/authn/config.go
+++ b/authn/config.go
@@ -24,11 +24,11 @@ func (c *VerifierConfig) RegisterFlags(prefix string, fs *flag.FlagSet) {
 type TokenExchangeConfig struct {
 	// Token used to perform the exchange request.
 	Token string
-	// Url called to perform exhange request.
+	// Url called to perform exchange request.
 	TokenExchangeURL string
 }
 
 func (c *TokenExchangeConfig) RegisterFlags(prefix string, fs *flag.FlagSet) {
 	fs.StringVar(&c.Token, prefix+".token", "", "Token used to perform the exchange request.")
-	fs.StringVar(&c.TokenExchangeURL, prefix+".token-exchange-url", "", "Url called to perform exhange request.")
+	fs.StringVar(&c.TokenExchangeURL, prefix+".token-exchange-url", "", "Url called to perform exchange request.")
 }

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -17,6 +17,13 @@ import (
 	"github.com/grafana/authlib/internal/httpclient"
 )
 
+// Provided for mockability of client
+type TokenExchangeClientInterface interface {
+	Exchange(ctx context.Context, r TokenExchangeRequest) (*TokenExchangeResponse, error)
+}
+
+var _ TokenExchangeClientInterface = &TokenExchangeClient{}
+
 // ExchangeClientOpts allows setting custom parameters during construction.
 type ExchangeClientOpts func(c *TokenExchangeClient)
 
@@ -33,7 +40,7 @@ func NewTokenExchangeClient(cfg TokenExchangeConfig, opts ...ExchangeClientOpts)
 	}
 
 	if cfg.TokenExchangeURL == "" {
-		return nil, fmt.Errorf("missing required token exhange url")
+		return nil, fmt.Errorf("missing required token exchange url")
 	}
 
 	c := &TokenExchangeClient{
@@ -71,7 +78,7 @@ type TokenExchangeRequest struct {
 	Audiences []string `json:"audiences"`
 }
 
-type TokenExhangeResponse struct {
+type TokenExchangeResponse struct {
 	Token string
 }
 
@@ -95,7 +102,7 @@ type tokenExchangeData struct {
 	Token string `json:"token"`
 }
 
-func (c *TokenExchangeClient) Exhange(ctx context.Context, r TokenExchangeRequest) (*TokenExhangeResponse, error) {
+func (c *TokenExchangeClient) Exchange(ctx context.Context, r TokenExchangeRequest) (*TokenExchangeResponse, error) {
 	if r.Namespace == "" {
 		return nil, ErrMissingNamespace
 	}
@@ -107,7 +114,7 @@ func (c *TokenExchangeClient) Exhange(ctx context.Context, r TokenExchangeReques
 	key := r.hash()
 	token, ok := c.getCache(ctx, key)
 	if ok {
-		return &TokenExhangeResponse{Token: token}, nil
+		return &TokenExchangeResponse{Token: token}, nil
 	}
 
 	resp, err, _ := c.singlef.Do(key, func() (interface{}, error) {
@@ -154,7 +161,7 @@ func (c *TokenExchangeClient) Exhange(ctx context.Context, r TokenExchangeReques
 	}
 
 	response := resp.(tokenExchangeResponse)
-	return &TokenExhangeResponse{Token: response.Data.Token}, nil
+	return &TokenExchangeResponse{Token: response.Data.Token}, nil
 }
 
 func (c *TokenExchangeClient) withHeaders(r *http.Request) *http.Request {

--- a/authn/token_exchange_test.go
+++ b/authn/token_exchange_test.go
@@ -40,7 +40,7 @@ func TestNewTokenExchangeClient(t *testing.T) {
 	})
 }
 
-func Test_TokenExchangeClient_Exhange(t *testing.T) {
+func Test_TokenExchangeClient_Exchange(t *testing.T) {
 	setup := func(srv *httptest.Server) *TokenExchangeClient {
 		c, err := NewTokenExchangeClient(TokenExchangeConfig{
 			Token:            "some-token",
@@ -52,7 +52,7 @@ func Test_TokenExchangeClient_Exhange(t *testing.T) {
 
 	t.Run("should return error if namespace is empty", func(t *testing.T) {
 		c := setup(httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})))
-		res, err := c.Exhange(context.Background(), TokenExchangeRequest{})
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{})
 		assert.ErrorIs(t, err, ErrMissingNamespace)
 		assert.Nil(t, res)
 
@@ -60,7 +60,7 @@ func Test_TokenExchangeClient_Exhange(t *testing.T) {
 
 	t.Run("should return error if audiences is empty", func(t *testing.T) {
 		c := setup(httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})))
-		res, err := c.Exhange(context.Background(), TokenExchangeRequest{Namespace: "*"})
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "*"})
 		assert.ErrorIs(t, err, ErrMissingAudiences)
 		assert.Nil(t, res)
 	})
@@ -70,7 +70,7 @@ func Test_TokenExchangeClient_Exhange(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte("{}"))
 		})))
-		res, err := c.Exhange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service"}})
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service"}})
 		assert.ErrorIs(t, err, ErrInvalidExchangeResponse)
 		assert.Nil(t, res)
 	})
@@ -86,25 +86,25 @@ func Test_TokenExchangeClient_Exhange(t *testing.T) {
 			json.NewEncoder(&bytes.Buffer{})
 		})))
 
-		res, err := c.Exhange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service"}})
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service"}})
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		require.Equal(t, 1, calls)
 
 		// same namespace and audiences should load token from cache
-		res, err = c.Exhange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service"}})
+		res, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service"}})
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		require.Equal(t, 1, calls)
 
 		// different namespace should issue new token request
-		res, err = c.Exhange(context.Background(), TokenExchangeRequest{Namespace: "stack-1", Audiences: []string{"some-service"}})
+		res, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stack-1", Audiences: []string{"some-service"}})
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		require.Equal(t, 2, calls)
 
 		// different different audiences should issue new token request
-		res, err = c.Exhange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service-2"}})
+		res, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "*", Audiences: []string{"some-service-2"}})
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		require.Equal(t, 3, calls)


### PR DESCRIPTION
I have been meaning to fix the spelling.

The interface might be nice as callers can implement mocks and pass around the interface instead.