### PR TITLE
Authn: Update interface

### DIFF
--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -18,11 +18,11 @@ import (
 )
 
 // Provided for mockability of client
-type TokenExchangeClientInterface interface {
+type TokenExchanger interface {
 	Exchange(ctx context.Context, r TokenExchangeRequest) (*TokenExchangeResponse, error)
 }
 
-var _ TokenExchangeClientInterface = &TokenExchangeClient{}
+var _ TokenExchanger = &TokenExchangeClient{}
 
 // ExchangeClientOpts allows setting custom parameters during construction.
 type ExchangeClientOpts func(c *TokenExchangeClient)


### PR DESCRIPTION
Propose to use `TokenExchanger` instead of TokenExchangeClientInterface. This is what we used in [authz-service](https://github.com/grafana/authz-service/blob/main/pkg/authorizer/proxy/proxy.go#L25-L27)