### PR TITLE
Authn: Add interface for KeyRetriever and expose a default implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ import (
 type CustomClaims struct{}
 
 func main() {
-	verifier := authn.NewVerifier[CustomClaims](authn.IDVerifierConfig{
-		SigningKeysURL:   "<jwks url>",
+	verifier := authn.NewVerifier[CustomClaims](authn.VerifierConfig{
 		AllowedAudiences: []string{},
-	}, authn.TokenTypeID)
+	}, authn.TokenTypeID, authn.NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: "<jwks url>"}))
 
 	claims, err := verifier.Verify(context.Background(), "<token>")
 
@@ -86,7 +85,6 @@ func main() {
 
 	log.Println("Claims: ", claims)
 }
-
 ```
 
 The verifier is generic over jwt.Claims. Most common use cases will be to either verify Grafana issued ID-Token or Access token.

--- a/authn/config.go
+++ b/authn/config.go
@@ -8,17 +8,22 @@ import (
 )
 
 type VerifierConfig struct {
-	SigningKeysURL   string       `yaml:"signingKeysUrl"`
 	AllowedAudiences jwt.Audience `yaml:"allowedAudiences"`
 }
 
 func (c *VerifierConfig) RegisterFlags(prefix string, fs *flag.FlagSet) {
-	fs.StringVar(&c.SigningKeysURL, prefix+".signing-keys-url", "", "URL to jwks endpoint.")
-
 	fs.Func(prefix+".allowed-audiences", "Specifies a comma-separated list of allowed audiences.", func(v string) error {
 		c.AllowedAudiences = jwt.Audience(strings.Split(v, ","))
 		return nil
 	})
+}
+
+type KeyRetrieverConfig struct {
+	SigningKeysURL string `yaml:"signingKeysUrl"`
+}
+
+func (c *KeyRetrieverConfig) RegisterFlags(prefix string, fs *flag.FlagSet) {
+	fs.StringVar(&c.SigningKeysURL, prefix+".signing-keys-url", "", "URL to jwks endpoint.")
 }
 
 type TokenExchangeConfig struct {

--- a/authn/config_test.go
+++ b/authn/config_test.go
@@ -13,8 +13,28 @@ func TestVerifierConfig_RegisterFlags(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	cfg.RegisterFlags("test", fs)
 
-	err := fs.Parse([]string{"-test.allowed-audiences", "a,b,c", "-test.signing-keys-url", "localhost"})
+	err := fs.Parse([]string{"-test.allowed-audiences", "a,b,c"})
 	require.NoError(t, err)
 	require.Equal(t, jwt.Audience{"a", "b", "c"}, cfg.AllowedAudiences)
-	require.Equal(t, "localhost", cfg.SigningKeysURL)
+}
+
+func TestKeyRetrieverConfig_RegisterFlags(t *testing.T) {
+	var cfg KeyRetrieverConfig
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.RegisterFlags("test", fs)
+
+	err := fs.Parse([]string{"-test.signing-keys-url", "http://127.0.0.1/keys"})
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1/keys", cfg.SigningKeysURL)
+}
+
+func TestTokenExchangeConfig_RegisterFlags(t *testing.T) {
+	var cfg TokenExchangeConfig
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.RegisterFlags("test", fs)
+
+	err := fs.Parse([]string{"-test.token", "my-token", "-test.token-exchange-url", "http://127.0.0.1/token"})
+	require.NoError(t, err)
+	require.Equal(t, "my-token", cfg.Token)
+	require.Equal(t, "http://127.0.0.1/token", cfg.TokenExchangeURL)
 }

--- a/authn/jwks_test.go
+++ b/authn/jwks_test.go
@@ -24,7 +24,7 @@ func keys() []byte {
 	return data
 }
 
-func TestKeyService_Get(t *testing.T) {
+func TestDefaultKeyRetriever_Get(t *testing.T) {
 	var calls int
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -32,7 +32,9 @@ func TestKeyService_Get(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write(keys())
 	}))
-	service := newKeyService(server.URL)
+	service := NewKeyRetiever(KeyRetrieverConfig{
+		SigningKeysURL: server.URL,
+	})
 
 	t.Run("should fetched key if not cached", func(t *testing.T) {
 		key, err := service.Get(context.Background(), firstKeyID)

--- a/authn/verifier.go
+++ b/authn/verifier.go
@@ -27,18 +27,14 @@ type Claims[T any] struct {
 	Rest T
 }
 
-func NewVerifier[T any](cfg VerifierConfig, typ TokenType) *VerifierBase[T] {
-	return newVerifierWithKeyService[T](cfg, typ, newKeyService(cfg.SigningKeysURL))
-}
-
-func newVerifierWithKeyService[T any](cfg VerifierConfig, typ TokenType, keys *keyService) *VerifierBase[T] {
+func NewVerifier[T any](cfg VerifierConfig, typ TokenType, keys KeyRetriever) *VerifierBase[T] {
 	return &VerifierBase[T]{cfg, typ, keys}
 }
 
 type VerifierBase[T any] struct {
 	cfg       VerifierConfig
 	tokenType TokenType
-	keys      *keyService
+	keys      KeyRetriever
 }
 
 // Verify will parse and verify provided token using public key from `SigningKeysURL`.

--- a/authn/verifier.go
+++ b/authn/verifier.go
@@ -17,8 +17,7 @@ const (
 )
 
 type Verifier[T any] interface {
-	// Verify will parse and verify provided token using public key from `VerifierConfig.SigningKeysURL`.
-	// If `AllowedAudiences` was configured those will be validated as well.
+	// Verify will parse and verify provided token, if `AllowedAudiences` was configured those will be validated as well.
 	Verify(ctx context.Context, token string) (*Claims[T], error)
 }
 
@@ -37,8 +36,7 @@ type VerifierBase[T any] struct {
 	keys      KeyRetriever
 }
 
-// Verify will parse and verify provided token using public key from `SigningKeysURL`.
-// If `AllowedAudiences` was configured those will be validated as well.
+// Verify will parse and verify provided token, if `AllowedAudiences` was configured those will be validated as well.
 func (v *VerifierBase[T]) Verify(ctx context.Context, token string) (*Claims[T], error) {
 	parsed, err := jwt.ParseSigned(token)
 	if err != nil {

--- a/authn/verifier_access_token.go
+++ b/authn/verifier_access_token.go
@@ -2,8 +2,6 @@ package authn
 
 import (
 	"context"
-
-	"github.com/grafana/authlib/cache"
 )
 
 type AccessTokenClaims struct {
@@ -25,15 +23,9 @@ func (c AccessTokenClaims) NamespaceMatches(namespace string) bool {
 	return c.Namespace == namespace
 }
 
-func NewAccessTokenVerifier(cfg VerifierConfig) *AccessTokenVerifier {
+func NewAccessTokenVerifier(cfg VerifierConfig, keys KeyRetriever) *AccessTokenVerifier {
 	return &AccessTokenVerifier{
-		v: NewVerifier[AccessTokenClaims](cfg, TokenTypeAccess),
-	}
-}
-
-func NewAccessTokenVerifierWithCache(cfg VerifierConfig, cache cache.Cache) *AccessTokenVerifier {
-	return &AccessTokenVerifier{
-		v: newVerifierWithKeyService[AccessTokenClaims](cfg, TokenTypeAccess, newKeyServiceWithCache(cfg.SigningKeysURL, cache)),
+		v: NewVerifier[AccessTokenClaims](cfg, TokenTypeAccess, keys),
 	}
 }
 

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -2,8 +2,6 @@ package authn
 
 import (
 	"context"
-
-	"github.com/grafana/authlib/cache"
 )
 
 type IDTokenClaims struct {
@@ -23,15 +21,9 @@ func (c IDTokenClaims) NamespaceMatches(namespace string) bool {
 	return c.Namespace == namespace
 }
 
-func NewIDTokenVerifier(cfg VerifierConfig) *IDTokenVerifier {
+func NewIDTokenVerifier(cfg VerifierConfig, keys KeyRetriever) *IDTokenVerifier {
 	return &IDTokenVerifier{
-		v: NewVerifier[IDTokenClaims](cfg, TokenTypeID),
-	}
-}
-
-func NewIDTokenVerifierWithCache(cfg VerifierConfig, cache cache.Cache) *IDTokenVerifier {
-	return &IDTokenVerifier{
-		v: newVerifierWithKeyService[IDTokenClaims](cfg, TokenTypeID, newKeyServiceWithCache(cfg.SigningKeysURL, cache)),
+		v: NewVerifier[IDTokenClaims](cfg, TokenTypeID, keys),
 	}
 }
 

--- a/authn/verifier_test.go
+++ b/authn/verifier_test.go
@@ -68,9 +68,11 @@ func TestVerifier_Verify(t *testing.T) {
 
 	type CustomClaims struct{}
 
-	verifier := NewVerifier[CustomClaims](VerifierConfig{
-		SigningKeysURL: server.URL,
-	}, TokenTypeID)
+	verifier := NewVerifier[CustomClaims](
+		VerifierConfig{},
+		TokenTypeID,
+		NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: server.URL}),
+	)
 
 	t.Run("invalid: wrong token format", func(t *testing.T) {
 		claims, err := verifier.Verify(context.Background(), "not a jwt token")
@@ -85,9 +87,11 @@ func TestVerifier_Verify(t *testing.T) {
 	})
 
 	t.Run("invalid: transient http error", func(t *testing.T) {
-		verifier := NewVerifier[CustomClaims](VerifierConfig{
-			SigningKeysURL: "http://localhost:8000/v1/unknown",
-		}, TokenTypeID)
+		verifier := NewVerifier[CustomClaims](
+			VerifierConfig{},
+			TokenTypeID,
+			NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: "http://localhost:8000/v1/unknown"}),
+		)
 		claims, err := verifier.Verify(context.Background(), signFist(t))
 		assert.ErrorIs(t, err, ErrFetchingSigningKey)
 		assert.Nil(t, claims)
@@ -97,9 +101,12 @@ func TestVerifier_Verify(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
-		verifier := NewVerifier[CustomClaims](VerifierConfig{
-			SigningKeysURL: server.URL,
-		}, TokenTypeID)
+
+		verifier := NewVerifier[CustomClaims](
+			VerifierConfig{},
+			TokenTypeID,
+			NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: server.URL}),
+		)
 		claims, err := verifier.Verify(context.Background(), signFist(t))
 		assert.ErrorIs(t, err, ErrFetchingSigningKey)
 		assert.Nil(t, claims)
@@ -117,47 +124,55 @@ func TestVerifier_Verify(t *testing.T) {
 			w.Write([]byte(response))
 		}))
 
-		verifier := NewVerifier[CustomClaims](VerifierConfig{
-			SigningKeysURL: server.URL,
-		}, TokenTypeID)
+		verifier := NewVerifier[CustomClaims](
+			VerifierConfig{},
+			TokenTypeID,
+			NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: server.URL}),
+		)
 		claims, err := verifier.Verify(context.Background(), signSecond(t))
 		assert.ErrorIs(t, err, ErrInvalidSigningKey)
 		assert.Nil(t, claims)
 	})
 
 	t.Run("invalid: token audience not allowed", func(t *testing.T) {
-		verifier := NewVerifier[CustomClaims](VerifierConfig{
-			SigningKeysURL:   server.URL,
-			AllowedAudiences: []string{"stack:2"},
-		}, TokenTypeID)
+		verifier := NewVerifier[CustomClaims](
+			VerifierConfig{AllowedAudiences: []string{"stack:2"}},
+			TokenTypeID,
+			NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: server.URL}),
+		)
 		claims, err := verifier.Verify(context.Background(), signFist(t))
 		assert.ErrorIs(t, err, ErrInvalidAudience)
 		assert.Nil(t, claims)
 	})
 
 	t.Run("invalid: token expired", func(t *testing.T) {
-		verifier := NewVerifier[CustomClaims](VerifierConfig{
-			SigningKeysURL: server.URL,
-		}, TokenTypeID)
+		verifier := NewVerifier[CustomClaims](
+			VerifierConfig{},
+			TokenTypeID,
+			NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: server.URL}),
+		)
 		claims, err := verifier.Verify(context.Background(), signExpired(t))
 		assert.ErrorIs(t, err, ErrExpiredToken)
 		assert.Nil(t, claims)
 	})
 
 	t.Run("invalid: wrong token typ", func(t *testing.T) {
-		verifier := NewVerifier[CustomClaims](VerifierConfig{
-			SigningKeysURL: server.URL,
-		}, TokenTypeAccess)
+		verifier := NewVerifier[CustomClaims](
+			VerifierConfig{},
+			TokenTypeAccess,
+			NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: server.URL}),
+		)
 		claims, err := verifier.Verify(context.Background(), signFist(t))
 		assert.ErrorIs(t, err, ErrInvalidTokenType)
 		assert.Nil(t, claims)
 	})
 
 	t.Run("valid: token audience allowed", func(t *testing.T) {
-		verifier := NewVerifier[CustomClaims](VerifierConfig{
-			SigningKeysURL:   server.URL,
-			AllowedAudiences: []string{"stack:1"},
-		}, TokenTypeID)
+		verifier := NewVerifier[CustomClaims](
+			VerifierConfig{AllowedAudiences: []string{"stack:1"}},
+			TokenTypeID,
+			NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: server.URL}),
+		)
 		claims, err := verifier.Verify(context.Background(), signFist(t))
 		assert.NoError(t, err)
 		assert.NotNil(t, claims)

--- a/authz/client.go
+++ b/authz/client.go
@@ -74,7 +74,7 @@ func newClient(cfg Config, opts ...clientOption) (*clientImpl, error) {
 		})
 	}
 
-	client.verifier = authn.NewVerifier[customClaims](authn.VerifierConfig{SigningKeysURL: cfg.JWKsURL}, authn.TokenTypeID)
+	client.verifier = authn.NewVerifier[customClaims](authn.VerifierConfig{}, authn.TokenTypeID, authn.NewKeyRetiever(authn.KeyRetrieverConfig{SigningKeysURL: cfg.JWKsURL}))
 
 	// create httpClient, if not already present
 	if client.client == nil {


### PR DESCRIPTION
It's common to construct `AccessTokenVerifier` and `IDTokenVerifier` together. And they always use the same `SingingKeysURL`. Right now if you construct them both they would use different singing keys logic, i.e. they would separately fetch and cache public jwks.

In this pr I propose to expose and interface `KeyRetriever` and a default implementation that you need to pass when creating a new verifier. This makes is easier to share the logic and underlying store. It is a breaking change but there is not too many places we would need to update