### PR TITLE
Authn: Allow configuring the key retriever http client

### DIFF
--- a/authn/jwks.go
+++ b/authn/jwks.go
@@ -42,7 +42,7 @@ func NewKeyRetriever(cfg KeyRetrieverConfig, opt ...DefaultKeyRetrieverOption) *
 	return s
 }
 
-// WithHTTPClientKeyRetrieverOpt allows setting the HTTP client to be used by the token exchange client.
+// WithHTTPClientKeyRetrieverOpt allows setting the HTTP client to be used by the key retriever.
 func WithHTTPClientKeyRetrieverOpt(client *http.Client) DefaultKeyRetrieverOption {
 	return func(c *DefaultKeyRetriever) {
 		c.client = client

--- a/authn/jwks.go
+++ b/authn/jwks.go
@@ -18,26 +18,42 @@ type KeyRetriever interface {
 	Get(ctx context.Context, keyID string) (*jose.JSONWebKey, error)
 }
 
+type DefaultKeyRetrieverOption func(*DefaultKeyRetriever)
+
 const (
 	cacheTTL             = 10 * time.Minute
 	cacheCleanupInterval = 10 * time.Minute
 )
 
-func NewKeyRetriever(cfg KeyRetrieverConfig) *DefaultKeyRetriever {
-	return &DefaultKeyRetriever{
+func NewKeyRetriever(cfg KeyRetrieverConfig, opt ...DefaultKeyRetrieverOption) *DefaultKeyRetriever {
+	s := &DefaultKeyRetriever{
 		cfg: cfg,
 		c: cache.NewLocalCache(cache.Config{
 			Expiry:          cacheTTL,
 			CleanupInterval: cacheCleanupInterval,
 		}),
-		s: &singleflight.Group{},
+		client: http.DefaultClient,
+		s:      &singleflight.Group{},
+	}
+
+	for _, o := range opt {
+		o(s)
+	}
+	return s
+}
+
+// WithHTTPClient allows setting the HTTP client to be used by the token exchange client.
+func WithHTTPClientRetrieverOpt(client *http.Client) DefaultKeyRetrieverOption {
+	return func(c *DefaultKeyRetriever) {
+		c.client = client
 	}
 }
 
 type DefaultKeyRetriever struct {
-	cfg KeyRetrieverConfig
-	s   *singleflight.Group
-	c   cache.Cache
+	cfg    KeyRetrieverConfig
+	client *http.Client
+	s      *singleflight.Group
+	c      cache.Cache
 }
 
 func (s *DefaultKeyRetriever) Get(ctx context.Context, keyID string) (*jose.JSONWebKey, error) {
@@ -82,7 +98,7 @@ func (s *DefaultKeyRetriever) fetchJWKS(ctx context.Context) (*jose.JSONWebKeySe
 		return nil, err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: request error", ErrFetchingSigningKey)
 	}

--- a/authn/jwks.go
+++ b/authn/jwks.go
@@ -42,8 +42,8 @@ func NewKeyRetriever(cfg KeyRetrieverConfig, opt ...DefaultKeyRetrieverOption) *
 	return s
 }
 
-// WithHTTPClient allows setting the HTTP client to be used by the token exchange client.
-func WithHTTPClientRetrieverOpt(client *http.Client) DefaultKeyRetrieverOption {
+// WithHTTPClientKeyRetrieverOpt allows setting the HTTP client to be used by the token exchange client.
+func WithHTTPClientKeyRetrieverOpt(client *http.Client) DefaultKeyRetrieverOption {
 	return func(c *DefaultKeyRetriever) {
 		c.client = client
 	}

--- a/authn/jwks.go
+++ b/authn/jwks.go
@@ -20,6 +20,13 @@ type KeyRetriever interface {
 
 type DefaultKeyRetrieverOption func(*DefaultKeyRetriever)
 
+// WithHTTPClientKeyRetrieverOpt allows setting the HTTP client to be used by the key retriever.
+func WithHTTPClientKeyRetrieverOpt(client *http.Client) DefaultKeyRetrieverOption {
+	return func(c *DefaultKeyRetriever) {
+		c.client = client
+	}
+}
+
 const (
 	cacheTTL             = 10 * time.Minute
 	cacheCleanupInterval = 10 * time.Minute
@@ -40,13 +47,6 @@ func NewKeyRetriever(cfg KeyRetrieverConfig, opt ...DefaultKeyRetrieverOption) *
 		o(s)
 	}
 	return s
-}
-
-// WithHTTPClientKeyRetrieverOpt allows setting the HTTP client to be used by the key retriever.
-func WithHTTPClientKeyRetrieverOpt(client *http.Client) DefaultKeyRetrieverOption {
-	return func(c *DefaultKeyRetriever) {
-		c.client = client
-	}
 }
 
 type DefaultKeyRetriever struct {


### PR DESCRIPTION
In the scope of the `UniStore` work, given `Grafana` is relying on a self signed https certificate for local testing, I'd like to be able to replace the client with one that has `tls.Config{InsecureSkipVerify: true}`