### PR TITLE
AuthZ: Remove ID Token from the interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func main() {
 	client, err := authz.NewEnforcementClient(authz.Config{
 		APIURL: "http://localhost:3000",
 		Token:  "<service account token>",
-	}, verifier)
+	})
 
 	if err != nil {
 		log.Fatal("failed to construct authz client", err)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Grafana needs to be configured with the `accessControlOnCall` feature toggle set
 
 ```ini
 [feature_toggles]
-enable = accessControlOnCall 
+enable = accessControlOnCall
 ```
 
 ## Examples
@@ -30,11 +30,15 @@ import (
 )
 
 func main() {
+	verifier := authn.NewIDTokenVerifier(
+		authn.VerifierConfig{AllowedAudiences: []string{}},
+		authn.NewKeyRetriever(KeyRetrieverConfig{SigningKeysURL: "<jwks url>"})
+	)
+
 	client, err := authz.NewEnforcementClient(authz.Config{
 		APIURL:  "http://localhost:3000",
 		Token:   "<service account token>",
-		JWKsURL: "<jwks url>",
-	})
+	}, verifier)
 
 	if err != nil {
 		log.Fatal("failed to construct authz client", err)
@@ -75,7 +79,7 @@ type CustomClaims struct{}
 func main() {
 	verifier := authn.NewVerifier[CustomClaims](authn.VerifierConfig{
 		AllowedAudiences: []string{},
-	}, authn.TokenTypeID, authn.NewKeyRetiever(KeyRetrieverConfig{SigningKeysURL: "<jwks url>"}))
+	}, authn.TokenTypeID, authn.NewKeyRetriever(KeyRetrieverConfig{SigningKeysURL: "<jwks url>"}))
 
 	claims, err := verifier.Verify(context.Background(), "<token>")
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ import (
 )
 
 func main() {
-	verifier := authn.NewIDTokenVerifier(
-		authn.VerifierConfig{AllowedAudiences: []string{}},
-		authn.NewKeyRetriever(authn.KeyRetrieverConfig{SigningKeysURL: "<jwks url>"}),
-	)
-
 	client, err := authz.NewEnforcementClient(authz.Config{
 		APIURL: "http://localhost:3000",
 		Token:  "<service account token>",
@@ -44,7 +39,7 @@ func main() {
 		log.Fatal("failed to construct authz client", err)
 	}
 
-	ok, err := client.HasAccess(context.Background(), "<id token>", "users:read", authz.Resource{
+	ok, err := client.HasAccess(context.Background(), "<namespaced id>", "users:read", authz.Resource{
 		Kind: "users",
 		Attr: "id",
 		ID:   "1",

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ import (
 func main() {
 	verifier := authn.NewIDTokenVerifier(
 		authn.VerifierConfig{AllowedAudiences: []string{}},
-		authn.NewKeyRetriever(KeyRetrieverConfig{SigningKeysURL: "<jwks url>"})
+		authn.NewKeyRetriever(authn.KeyRetrieverConfig{SigningKeysURL: "<jwks url>"}),
 	)
 
 	client, err := authz.NewEnforcementClient(authz.Config{
-		APIURL:  "http://localhost:3000",
-		Token:   "<service account token>",
+		APIURL: "http://localhost:3000",
+		Token:  "<service account token>",
 	}, verifier)
 
 	if err != nil {

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/cache"
 )
 
@@ -52,7 +53,7 @@ func TestClientImpl_Search(t *testing.T) {
 			c, err := newClient(Config{
 				APIURL: server.URL,
 				Token:  "aabbcc",
-			}, withCache(testCache))
+			}, authn.NewIDTokenVerifier(authn.VerifierConfig{}, authn.NewKeyRetriever(authn.KeyRetrieverConfig{})), withCache(testCache))
 			require.NoError(t, err)
 
 			c.client = server.Client()

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -40,7 +40,7 @@ func TestClientImpl_Search(t *testing.T) {
 			d := []byte{}
 			if tt.query.Action != "" {
 				// Using a string instead of an int on purpose as this is what is returned by the API.
-				d, _ = json.Marshal(map[string]map[string][]string{fmt.Sprintf("%v", strings.Split(tt.query.NamespacedID, ":")[1]): {tt.query.Action: perms[tt.query.Action]}})
+				d, _ = json.Marshal(map[string]map[string][]string{fmt.Sprintf("%v", strings.Split(string(tt.query.NamespacedID), ":")[1]): {tt.query.Action: perms[tt.query.Action]}})
 			}
 			require.Equal(t, r.Header.Get("Authorization"), "Bearer aabbcc")
 			require.Equal(t, r.URL.Path, searchPath)

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/cache"
 )
 
@@ -53,7 +52,7 @@ func TestClientImpl_Search(t *testing.T) {
 			c, err := newClient(Config{
 				APIURL: server.URL,
 				Token:  "aabbcc",
-			}, authn.NewIDTokenVerifier(authn.VerifierConfig{}, authn.NewKeyRetriever(authn.KeyRetrieverConfig{})), withCache(testCache))
+			}, withCache(testCache))
 			require.NoError(t, err)
 
 			c.client = server.Client()

--- a/authz/enforcement.go
+++ b/authz/enforcement.go
@@ -64,7 +64,7 @@ func NewEnforcementClient(cfg Config, opt ...ClientOption) (*EnforcementClientIm
 }
 
 func (s *EnforcementClientImpl) fetchPermissions(ctx context.Context,
-	namespacedID string, action string, resources ...Resource) (permissions, error) {
+	namespacedID NamespacedID, action string, resources ...Resource) (permissions, error) {
 	var query searchQuery
 
 	if s.queryTemplate != nil && s.queryTemplate.ActionPrefix != "" &&
@@ -94,7 +94,7 @@ func (s *EnforcementClientImpl) fetchPermissions(ctx context.Context,
 	return nil, nil
 }
 
-func (s *EnforcementClientImpl) Compile(ctx context.Context, namespacedID string,
+func (s *EnforcementClientImpl) Compile(ctx context.Context, namespacedID NamespacedID,
 	action string, kinds ...string) (Checker, error) {
 	permissions, err := s.fetchPermissions(ctx, namespacedID, action)
 	if err != nil {
@@ -116,7 +116,7 @@ func resourcesKind(resources ...Resource) []string {
 	return kinds
 }
 
-func (s *EnforcementClientImpl) HasAccess(ctx context.Context, namespacedID string,
+func (s *EnforcementClientImpl) HasAccess(ctx context.Context, namespacedID NamespacedID,
 	action string, resources ...Resource) (bool, error) {
 	permissions, err := s.fetchPermissions(ctx, namespacedID, action, resources...)
 	if err != nil {
@@ -128,7 +128,7 @@ func (s *EnforcementClientImpl) HasAccess(ctx context.Context, namespacedID stri
 
 // Experimental: LookupResources returns the resources that the user has access to for the given action.
 // Resource expansion is still not supported in this method.
-func (s *EnforcementClientImpl) LookupResources(ctx context.Context, namespacedID string, action string) ([]Resource, error) {
+func (s *EnforcementClientImpl) LookupResources(ctx context.Context, namespacedID NamespacedID, action string) ([]Resource, error) {
 	permissions, err := s.fetchPermissions(ctx, namespacedID, action)
 	if err != nil {
 		return nil, err

--- a/authz/enforcement.go
+++ b/authz/enforcement.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/cache"
 )
 
@@ -45,7 +46,7 @@ func WithSearchByPrefix(prefix string) ClientOption {
 	}
 }
 
-func NewEnforcementClient(cfg Config, opt ...ClientOption) (*EnforcementClientImpl, error) {
+func NewEnforcementClient(cfg Config, verifier *authn.IDTokenVerifier, opt ...ClientOption) (*EnforcementClientImpl, error) {
 	s := &EnforcementClientImpl{
 		client:        nil,
 		queryTemplate: nil,
@@ -56,7 +57,7 @@ func NewEnforcementClient(cfg Config, opt ...ClientOption) (*EnforcementClientIm
 	}
 
 	var err error
-	if s.client, err = newClient(cfg, s.clientOpts...); err != nil {
+	if s.client, err = newClient(cfg, verifier, s.clientOpts...); err != nil {
 		return nil, err
 	}
 

--- a/authz/enforcement_test.go
+++ b/authz/enforcement_test.go
@@ -12,7 +12,7 @@ import (
 func TestEnforcementClientImpl_fetchPermissions_queryPreload(t *testing.T) {
 	tests := []struct {
 		name         string
-		namespacedID string
+		namespacedID NamespacedID
 		action       string
 		resources    []Resource
 		preloadQuery *searchQuery
@@ -63,7 +63,7 @@ func TestEnforcementClientImpl_HasAccess(t *testing.T) {
 	tests := []struct {
 		name         string
 		permissions  map[string][]string
-		namespacedID string
+		namespacedID NamespacedID
 		action       string
 		resources    []Resource
 		wantQuery    searchQuery
@@ -168,7 +168,7 @@ func TestEnforcementClientImpl_HasAccess(t *testing.T) {
 func TestEnforcementClientImpl_LookupResources(t *testing.T) {
 	tests := []struct {
 		name        string
-		idToken     string
+		namespaceID NamespacedID
 		action      string
 		permissions permissionsByID
 		want        []Resource
@@ -176,9 +176,9 @@ func TestEnforcementClientImpl_LookupResources(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:    "no permissions",
-			idToken: "jwt_id_token",
-			action:  "teams:read",
+			name:        "no permissions",
+			namespaceID: "user:12",
+			action:      "teams:read",
 			permissions: permissionsByID{
 				1: map[string][]string{},
 			},
@@ -186,9 +186,9 @@ func TestEnforcementClientImpl_LookupResources(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "permission filtering works",
-			idToken: "jwt_id_token",
-			action:  "teams:write",
+			name:        "permission filtering works",
+			namespaceID: "user:12",
+			action:      "teams:write",
 			permissions: permissionsByID{
 				1: map[string][]string{
 					"teams:read": {"teams:id:1", "teams:id:2"},
@@ -198,9 +198,9 @@ func TestEnforcementClientImpl_LookupResources(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "has permissions",
-			idToken: "jwt_id_token",
-			action:  "teams:read",
+			name:        "has permissions",
+			namespaceID: "user:12",
+			action:      "teams:read",
 			permissions: permissionsByID{
 				1: map[string][]string{
 					"teams:read": {"teams:id:1", "teams:id:2"},
@@ -213,9 +213,9 @@ func TestEnforcementClientImpl_LookupResources(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "has permissions wildcard",
-			idToken: "jwt_id_token",
-			action:  "folders:read",
+			name:        "has permissions wildcard",
+			namespaceID: "user:12",
+			action:      "folders:read",
 			permissions: permissionsByID{
 				1: map[string][]string{
 					"folders:read": {"folders:*"},
@@ -228,7 +228,7 @@ func TestEnforcementClientImpl_LookupResources(t *testing.T) {
 		},
 		{
 			name:        "error fetching permissions",
-			idToken:     "jwt_id_token",
+			namespaceID: "user:12",
 			action:      "teams:read",
 			permissions: permissionsByID{},
 			mockErr:     ErrTooManyPermissions,
@@ -244,7 +244,7 @@ func TestEnforcementClientImpl_LookupResources(t *testing.T) {
 
 			mockClient.On("Search", mock.Anything, mock.Anything).Return(&searchResponse{Data: &tt.permissions}, tt.mockErr)
 
-			got, err := s.LookupResources(context.Background(), tt.idToken, tt.action)
+			got, err := s.LookupResources(context.Background(), tt.namespaceID, tt.action)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/authz/models.go
+++ b/authz/models.go
@@ -20,14 +20,14 @@ type client interface {
 type EnforcementClient interface {
 	// Compile generates a function to check whether the user has access to any scope of a given list of scopes.
 	// This is particularly useful when you want to verify access to a list of resources.
-	Compile(ctx context.Context, idToken string, action string, kinds ...string) (Checker, error)
+	Compile(ctx context.Context, namespacedID string, action string, kinds ...string) (Checker, error)
 
 	// HasAccess checks whether the user can perform the given action on any of the given resources.
 	// If the scope is empty, it checks whether the user can perform the action.
-	HasAccess(ctx context.Context, idToken string, action string, resources ...Resource) (bool, error)
+	HasAccess(ctx context.Context, namespacedID string, action string, resources ...Resource) (bool, error)
 
 	// Experimental: LookupResources returns the resources that the user has access to for the given action.
-	LookupResources(ctx context.Context, idToken string, action string) ([]Resource, error)
+	LookupResources(ctx context.Context, namespacedID string, action string) ([]Resource, error)
 }
 
 // Checker checks whether a user has access to any of the provided resources.
@@ -78,9 +78,5 @@ type searchQuery struct {
 	Action       string    `json:"action,omitempty" url:"action,omitempty"`
 	Scope        string    `json:"scope,omitempty" url:"scope,omitempty"`
 	NamespacedID string    `json:"namespacedId" url:"namespacedId,omitempty"`
-	IdToken      string    `json:"-" url:"-"`
 	Resource     *Resource `json:"-" url:"-"`
 }
-
-// customClaims is a placeholder for any potential additional claims in the id token.
-type customClaims struct{}

--- a/authz/models.go
+++ b/authz/models.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 )
 
+type NamespacedID string
+
 // HTTPRequestDoer performs HTTP requests.
 // The standard http.Client implements this interface.
 type HTTPRequestDoer interface {
@@ -20,14 +22,14 @@ type client interface {
 type EnforcementClient interface {
 	// Compile generates a function to check whether the user has access to any scope of a given list of scopes.
 	// This is particularly useful when you want to verify access to a list of resources.
-	Compile(ctx context.Context, namespacedID string, action string, kinds ...string) (Checker, error)
+	Compile(ctx context.Context, namespacedID NamespacedID, action string, kinds ...string) (Checker, error)
 
 	// HasAccess checks whether the user can perform the given action on any of the given resources.
 	// If the scope is empty, it checks whether the user can perform the action.
-	HasAccess(ctx context.Context, namespacedID string, action string, resources ...Resource) (bool, error)
+	HasAccess(ctx context.Context, namespacedID NamespacedID, action string, resources ...Resource) (bool, error)
 
 	// Experimental: LookupResources returns the resources that the user has access to for the given action.
-	LookupResources(ctx context.Context, namespacedID string, action string) ([]Resource, error)
+	LookupResources(ctx context.Context, namespacedID NamespacedID, action string) ([]Resource, error)
 }
 
 // Checker checks whether a user has access to any of the provided resources.
@@ -74,9 +76,9 @@ func (r *Resource) Scope() string {
 
 // searchQuery is the query to search for permissions.
 type searchQuery struct {
-	ActionPrefix string    `json:"actionPrefix,omitempty" url:"actionPrefix,omitempty"`
-	Action       string    `json:"action,omitempty" url:"action,omitempty"`
-	Scope        string    `json:"scope,omitempty" url:"scope,omitempty"`
-	NamespacedID string    `json:"namespacedId" url:"namespacedId,omitempty"`
-	Resource     *Resource `json:"-" url:"-"`
+	ActionPrefix string       `json:"actionPrefix,omitempty" url:"actionPrefix,omitempty"`
+	Action       string       `json:"action,omitempty" url:"action,omitempty"`
+	Scope        string       `json:"scope,omitempty" url:"scope,omitempty"`
+	NamespacedID NamespacedID `json:"namespacedId" url:"namespacedId,omitempty"`
+	Resource     *Resource    `json:"-" url:"-"`
 }

--- a/authz/models.go
+++ b/authz/models.go
@@ -54,9 +54,8 @@ type permissionsByID map[int64]permissions
 type permissions map[string][]string
 
 type Config struct {
-	APIURL  string
-	Token   string
-	JWKsURL string
+	APIURL string
+	Token  string
 }
 
 // Resource represents a resource in Grafana.


### PR DESCRIPTION
~~In scope of the `UniStore` work, I noticed it could be good to share the `IDTokenVerifier` between the authentication and authorization middlewares. The same way we can share a JWKs retriever between `IDTokenVerifier` and `AccessTokenVerifier`.~~

Instead of parsing the id token to extract the `namespacedID` on each authorization check (in other words instead of re-authenticating the user on each check), we'd now request the `namespacedID` to be provided instead. 