### PR TITLE
AuthZ: Add multi-tenant client

### DIFF
--- a/authn/caller_info.go
+++ b/authn/caller_info.go
@@ -1,0 +1,19 @@
+package authn
+
+import "context"
+
+type CallerAuthInfo struct {
+	IDTokenClaims     *Claims[IDTokenClaims]
+	AccessTokenClaims Claims[AccessTokenClaims]
+}
+
+type CallerAuthInfoContextKey struct{}
+
+func AddCallerAuthInfoToContext(ctx context.Context, info CallerAuthInfo) context.Context {
+	return context.WithValue(ctx, CallerAuthInfoContextKey{}, info)
+}
+
+func GetCallerAuthInfoFromContext(ctx context.Context) (CallerAuthInfo, bool) {
+	info, ok := ctx.Value(CallerAuthInfoContextKey{}).(CallerAuthInfo)
+	return info, ok
+}

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// TODO (gamab): Instatiate the AuthZ client
 // TODO (gamab): Caching
 // TODO (gamab): Logs
 // TODO (gamab): Traces

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// TODO (gamab): Instatiate the AuthZ client
+// TODO (gamab): Instantiate the AuthZ client
 // TODO (gamab): Namespace validation
 // TODO (gamab): Caching
 // TODO (gamab): Logs

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -1,0 +1,166 @@
+package authz
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/grafana/authlib/authn"
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	"github.com/grafana/authlib/cache"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TODO (gamab): Add caching
+// TODO (gamab): Logs
+// TODO (gamab): Traces
+// TODO (gamab): AccessToken in outgoing context
+// TODO (gamab): Make access token claims optional for dev purposes
+
+var (
+	ErrMissingConfig  = errors.New("missing config")
+	ErrMissingAction  = status.Errorf(codes.InvalidArgument, "missing action")
+	ErrMissingCaller  = status.Errorf(codes.Unauthenticated, "missing caller")
+	ErrReadPermission = status.Errorf(codes.PermissionDenied, "read permission failed")
+)
+
+type CheckRequest struct {
+	Caller     authn.CallerAuthInfo
+	StackID    int64
+	Action     string
+	Resources  *Resource
+	Contextual []Resource
+}
+
+type MultiTenantClient interface {
+	Check(ctx context.Context, req *CheckRequest) (bool, error)
+}
+
+type MultiTenantClientConfig struct {
+	remoteAddress string
+}
+
+var _ MultiTenantClient = (*LegacyClientImpl)(nil)
+
+type LegacyClientImpl struct {
+	authCfg  *MultiTenantClientConfig
+	clientV1 authzv1.AuthzServiceClient
+	cache    cache.Cache
+}
+
+func NewLegacyClient(cfg *MultiTenantClientConfig) (*LegacyClientImpl, error) {
+	if cfg == nil {
+		return nil, ErrMissingConfig
+	}
+	if cfg.remoteAddress == "" {
+		return nil, fmt.Errorf("missing remote address: %w", ErrMissingConfig)
+	}
+
+	return &LegacyClientImpl{
+		authCfg: cfg,
+		cache: cache.NewLocalCache(cache.Config{
+			Expiry:          cacheExp,
+			CleanupInterval: 1 * time.Minute,
+		}),
+	}, nil
+}
+
+func (r *CheckRequest) Validate() error {
+	if r.Action == "" {
+		return ErrMissingAction
+	}
+	if r.Caller.AccessTokenClaims.Subject == "" {
+		return ErrMissingCaller
+	}
+	return nil
+}
+
+func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, error) {
+	// No user => check on the service permissions
+	if req.Caller.IDTokenClaims == nil {
+		perms := req.Caller.AccessTokenClaims.Rest.Permissions
+		for _, p := range perms {
+			if p == req.Action {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	// Make sure the service is allowed to perform the requested action
+	if req.Caller.AccessTokenClaims.Rest.DelegatedPermissions == nil {
+		return false, nil
+	}
+	serviceIsAllowedAction := false
+	for _, p := range req.Caller.AccessTokenClaims.Rest.DelegatedPermissions {
+		if p == req.Action {
+			serviceIsAllowedAction = true
+			break
+		}
+	}
+	if !serviceIsAllowedAction {
+		return false, nil
+	}
+
+	// Instantiate a new context for the request
+	outCtx := NewOutgoingContext(ctx)
+
+	readReq := &authzv1.ReadRequest{
+		StackId: req.StackID,
+		Action:  req.Action,
+		Subject: req.Caller.IDTokenClaims.Subject,
+	}
+
+	// Query the authz service
+	resp, err := c.clientV1.Read(outCtx, readReq)
+	if err != nil {
+		return false, ErrReadPermission
+	}
+
+	objs := []string{}
+	for _, o := range resp.Data {
+		objs = append(objs, o.Object)
+	}
+
+	// FIXME (gamab): Read does not return nil currently
+	if req.Resources == nil {
+		// resp.Data is not nil => the user has the requested action (with or without resources)
+		return resp.Data != nil, nil
+	}
+
+	// TODO (gamab) Implement the checker
+
+	// checker := compileChecker(objs, req.Object.Kind, req.Parent.Kind)
+	// return checker(req.Object, req.Parent), nil
+	return false, nil
+}
+
+func NewOutgoingContext(ctx context.Context) context.Context {
+	out, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		<-ctx.Done()
+		cancel()
+	}()
+
+	return out
+}
+
+func ReadCacheKey(stackID int64, subject, action string) string {
+	return fmt.Sprintf("read-%d-%s-%s", stackID, subject, action)
+}
+
+func (c *LegacyClientImpl) cacheReadResult(ctx context.Context, scopes []string, key string) error {
+	buf := bytes.Buffer{}
+	err := gob.NewEncoder(&buf).Encode(scopes)
+	if err != nil {
+		return err
+	}
+
+	// Cache with default expiry
+	return c.cache.Set(ctx, key, buf.Bytes(), cache.DefaultExpiration)
+}

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -14,6 +14,7 @@ import (
 )
 
 // TODO (gamab): Instatiate the AuthZ client
+// TODO (gamab): Namespace validation
 // TODO (gamab): Caching
 // TODO (gamab): Logs
 // TODO (gamab): Traces

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -26,7 +26,6 @@ var (
 	ErrMissingAction  = status.Errorf(codes.InvalidArgument, "missing action")
 	ErrMissingCaller  = status.Errorf(codes.Unauthenticated, "missing caller")
 	ErrReadPermission = status.Errorf(codes.PermissionDenied, "read permission failed")
-	ErrCaching        = status.Errorf(codes.Internal, "caching failed")
 )
 
 type CheckRequest struct {

--- a/authz/multitenant_client_test.go
+++ b/authz/multitenant_client_test.go
@@ -1,0 +1,1 @@
+package authz

--- a/authz/multitenant_client_test.go
+++ b/authz/multitenant_client_test.go
@@ -1,1 +1,216 @@
 package authz
+
+import (
+	"testing"
+
+	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReadResult(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *authzv1.ReadResponse
+		want *ReadResult
+	}{
+		{
+			name: "User does not have action",
+			resp: &authzv1.ReadResponse{
+				Found: false,
+				Data:  []*authzv1.ReadResponse_Data{},
+			},
+			want: &ReadResult{
+				Found: false,
+			},
+		},
+		{
+			name: "User has a scopeless action",
+			resp: &authzv1.ReadResponse{
+				Found: true,
+				Data:  []*authzv1.ReadResponse_Data{},
+			},
+			want: &ReadResult{Found: true},
+		},
+		{
+			name: "User has the action",
+			resp: &authzv1.ReadResponse{
+				Found: true,
+				Data:  []*authzv1.ReadResponse_Data{{Object: "dashboards:uid:1"}},
+			},
+			want: &ReadResult{
+				Found:    true,
+				Scopes:   map[string]bool{"dashboards:uid:1": true},
+				Wildcard: map[string]bool{},
+			},
+		},
+		{
+			name: "User has the action on a wildcard",
+			resp: &authzv1.ReadResponse{
+				Found: true,
+				Data:  []*authzv1.ReadResponse_Data{{Object: "dashboards:*"}},
+			},
+			want: &ReadResult{
+				Found:    true,
+				Scopes:   map[string]bool{},
+				Wildcard: map[string]bool{"dashboards": true},
+			},
+		},
+		{
+			name: "User has the action on a wildcard and a specific scope",
+			resp: &authzv1.ReadResponse{
+				Found: true,
+				Data:  []*authzv1.ReadResponse_Data{{Object: "dashboards:*"}, {Object: "dashboards:uid:1"}},
+			},
+			want: &ReadResult{
+				Found:    true,
+				Scopes:   map[string]bool{"dashboards:uid:1": true},
+				Wildcard: map[string]bool{"dashboards": true},
+			},
+		},
+		{
+			name: "User has the action on wildcards of different kinds",
+			resp: &authzv1.ReadResponse{
+				Found: true,
+				Data:  []*authzv1.ReadResponse_Data{{Object: "dashboards:*"}, {Object: "folders:*"}},
+			},
+			want: &ReadResult{
+				Found:    true,
+				Scopes:   map[string]bool{},
+				Wildcard: map[string]bool{"dashboards": true, "folders": true},
+			},
+		},
+		{
+			name: "User has the action on the master wildcard",
+			resp: &authzv1.ReadResponse{
+				Found: true,
+				Data:  []*authzv1.ReadResponse_Data{{Object: "*"}},
+			},
+			want: &ReadResult{
+				Found:    true,
+				Scopes:   map[string]bool{},
+				Wildcard: map[string]bool{"*": true},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewReadResult(tt.resp)
+
+			require.Equal(t, tt.want.Found, got.Found)
+			require.Len(t, got.Scopes, len(tt.want.Scopes))
+			require.Len(t, got.Wildcard, len(tt.want.Wildcard))
+
+			for k, v := range tt.want.Scopes {
+				require.Equal(t, v, got.Scopes[k])
+			}
+			for k, v := range tt.want.Wildcard {
+				require.Equal(t, v, got.Wildcard[k])
+			}
+		})
+	}
+}
+
+func TestReadResult_Check(t *testing.T) {
+	tests := []struct {
+		name      string
+		res       ReadResult
+		resources []Resource
+		want      bool
+	}{
+		{
+			name: "User does not have action",
+			res: ReadResult{
+				Found: false,
+			},
+			resources: []Resource{},
+			want:      false,
+		},
+		{
+			name: "User has a scopeless action",
+			res: ReadResult{
+				Found: true,
+			},
+			resources: []Resource{},
+			want:      true,
+		},
+		{
+			name: "User has a scopeless action but requested a resource",
+			res: ReadResult{
+				Found: true,
+			},
+			resources: []Resource{{Kind: "dashboards", Attr: "uid", ID: "1"}},
+			want:      false,
+		},
+		{
+			name: "User has action on a specific scope",
+			res: ReadResult{
+				Found:  true,
+				Scopes: map[string]bool{"dashboards:uid:1": true},
+			},
+			resources: []Resource{{Kind: "dashboards", Attr: "uid", ID: "1"}},
+			want:      true,
+		},
+		{
+			name: "User has action on a specific scope but not on the requested resource",
+			res: ReadResult{
+				Found:  true,
+				Scopes: map[string]bool{"dashboards:uid:1": true},
+			},
+			resources: []Resource{{Kind: "dashboards", Attr: "uid", ID: "2"}},
+			want:      false,
+		},
+		{
+			name: "User has action on a wildcard",
+			res: ReadResult{
+				Found:    true,
+				Wildcard: map[string]bool{"dashboards": true},
+			},
+			resources: []Resource{{Kind: "dashboards", Attr: "uid", ID: "1"}},
+			want:      true,
+		},
+		{
+			name: "User has action on a wildcard but not on the requested resource",
+			res: ReadResult{
+				Found:    true,
+				Wildcard: map[string]bool{"dashboards": true},
+			},
+			resources: []Resource{{Kind: "folders", Attr: "uid", ID: "1"}},
+			want:      false,
+		},
+		{
+			name: "User has action on the master wildcard",
+			res: ReadResult{
+				Found:    true,
+				Wildcard: map[string]bool{"*": true},
+			},
+			resources: []Resource{{Kind: "dashboards", Attr: "uid", ID: "1"}},
+			want:      true,
+		},
+		{
+			name: "User has action on one of the requested resources",
+			res: ReadResult{
+				Found:    true,
+				Scopes:   map[string]bool{"folders:uid:1": true},
+				Wildcard: map[string]bool{},
+			},
+			resources: []Resource{{Kind: "dashboards", Attr: "uid", ID: "1"}, {Kind: "folders", Attr: "uid", ID: "1"}},
+			want:      true,
+		},
+		{
+			name: "User has action on none of the requested resources",
+			res: ReadResult{
+				Found:    true,
+				Scopes:   map[string]bool{"folders:uid:2": true},
+				Wildcard: map[string]bool{},
+			},
+			resources: []Resource{{Kind: "dashboards", Attr: "uid", ID: "1"}, {Kind: "folders", Attr: "uid", ID: "1"}},
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.res.Check(tt.resources...)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/sync v0.6.0
+	golang.org/x/sync v0.7.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240604185151-ef581f913117
-	google.golang.org/grpc v1.64.0
+	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
@@ -54,8 +54,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20240604185151-ef581f913117 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20240604185151-ef581f913117/go.mod h1:OimBR/bc1wPO9iV4NC2bpyjy3VnAwZh5EBPQdtaE5oo=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117 h1:1GBuWVLM/KMVUv1t1En5Gs+gFZCNd360GGb4sSxtrhU=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240604185151-ef581f913117/go.mod h1:EfXuqaE1J41VCDicxHzUDm+8rk+7ZdXzHV0IhO/I6s0=
-google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
-google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
+google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
+google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
 google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
 google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR adds the first elements of the new multi-tenant AuthZ client.

Mostly we introduce a new caller concept, which is the bundle of an access token and id token, that we will use to authorize requests:

```mermaid
classDiagram
class CallerAuthInfo{
+IdClaims
+AccessClaims
}
```

Then we implement the following flow, wrapping the Read endpoint of the Authorization Service (proxy) and enforcing access control:

```mermaid
flowchart TD
A[Check<br>Caller, StackID<br>Action, Resource, CtxResource ] --> B{if Caller is Service}
B -->|yes| C{if Caller.AccessClaims<br>has action in permission}
C -->|yes| YES[YES]
C -->|no| NO[NO]
B -->|no| F{if Caller.AccessClaims<br>has action in delegatedPermission}
F -->|no| NO1[NO]
F -->|yes| G[read user permissions<br>Caller.IdClaims.NamespaceID, StackID, Action]
G --> H{ for R in Resource, CtxResource }
H -->|next| I{ if User has Action on R}
I -->|yes| YES1[YES]
I -->|no| H
H -->|end| NO1[NO]
```

After this PR I'll need to:

- [x] Fix authz read interface
- [ ] Instantiate the grpc client
- [ ] Namespace validation
- [ ] Add caching
- [ ] Logs
- [ ] Traces
- [ ] AccessToken in outgoing context
- [ ] Make access token claims optional for dev purposes
