### PR TITLE
AuthN: gRPC Client Interceptor

### DIFF
--- a/authn/errors.go
+++ b/authn/errors.go
@@ -16,6 +16,8 @@ var (
 
 	ErrExpiredToken    = fmt.Errorf("%w: expired token", errInvalidToken)
 	ErrInvalidAudience = fmt.Errorf("%w: invalid audience", errInvalidToken)
+
+	ErrMissingConfig = errors.New("missing config")
 )
 
 func IsInvalidTokenErr(err error) bool {

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -95,7 +95,7 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 
 	token, err := gci.tokenClient.Exchange(ctx, *gci.cfg.TokenRequest)
 	if err != nil {
-		return nil, err
+		return ctx, err
 	}
 
 	md.Set(gci.cfg.AccessTokenMetadataKey, token.Token)

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -1,0 +1,98 @@
+package authn
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// TODO (gamab): ID Token
+// TODO (gamab): Make Access Token optional?
+// TODO (gamab): Organization/Stack ID
+// TODO (gamab): Readme
+
+// GrpcClientConfig holds the configuration for the gRPC client interceptor.
+type GrpcClientConfig struct {
+	// AccessTokenMetadataKey is the key used to store the access token in the outgoing context metadata.
+	AccessTokenMetadataKey string
+	// TokenClientConfig holds the configuration for the token exchange client.
+	// Not required if TokenClient is provided.
+	TokenClientConfig *TokenExchangeConfig
+	// TokenRequest is the token request to be used for token exchange.
+	// This assumes the token request is static and does not change.
+	TokenRequest *TokenExchangeRequest
+}
+
+// GrpcClientInterceptor is a gRPC client interceptor that adds an access token to the outgoing context metadata.
+type GrpcClientInterceptor struct {
+	cfg         *GrpcClientConfig
+	tokenClient TokenExchanger
+}
+
+type GrpcClientInterceptorOption func(*GrpcClientInterceptor) error
+
+func WithTokenClientOption(tokenClient TokenExchanger) GrpcClientInterceptorOption {
+	return func(gci *GrpcClientInterceptor) error {
+		gci.tokenClient = tokenClient
+		return nil
+	}
+}
+
+func NewGrpcClientInterceptor(cfg *GrpcClientConfig, opts ...GrpcClientInterceptorOption) (*GrpcClientInterceptor, error) {
+	gci := &GrpcClientInterceptor{cfg: cfg}
+
+	if gci.cfg.TokenRequest == nil {
+		return nil, fmt.Errorf("missing required token request: %w", ErrMissingConfig)
+	}
+
+	for _, opt := range opts {
+		_ = opt(gci)
+	}
+
+	if gci.tokenClient == nil {
+		if gci.cfg.TokenClientConfig == nil {
+			return nil, fmt.Errorf("missing required token client config: %w", ErrMissingConfig)
+		}
+
+		tokenClient, err := NewTokenExchangeClient(*gci.cfg.TokenClientConfig)
+		if err != nil {
+			return nil, err
+		}
+		gci.tokenClient = tokenClient
+	}
+
+	return gci, nil
+}
+
+func (gci *GrpcClientInterceptor) UnaryClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	ctx, err := gci.wrapContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	return invoker(ctx, method, req, reply, cc, opts...)
+}
+
+func (gci *GrpcClientInterceptor) StreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	ctx, err := gci.wrapContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return streamer(ctx, desc, cc, method, opts...)
+}
+
+func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Context, error) {
+	md := metadata.Pairs()
+
+	token, err := gci.tokenClient.Exchange(ctx, *gci.cfg.TokenRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	md.Set(gci.cfg.AccessTokenMetadataKey, token.Token)
+
+	return metadata.NewOutgoingContext(ctx, md), nil
+}

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -34,12 +34,11 @@ type GrpcClientInterceptor struct {
 	tokenClient TokenExchanger
 }
 
-type GrpcClientInterceptorOption func(*GrpcClientInterceptor) error
+type GrpcClientInterceptorOption func(*GrpcClientInterceptor)
 
 func WithTokenClientOption(tokenClient TokenExchanger) GrpcClientInterceptorOption {
-	return func(gci *GrpcClientInterceptor) error {
+	return func(gci *GrpcClientInterceptor) {
 		gci.tokenClient = tokenClient
-		return nil
 	}
 }
 
@@ -55,7 +54,7 @@ func NewGrpcClientInterceptor(cfg *GrpcClientConfig, opts ...GrpcClientIntercept
 	}
 
 	for _, opt := range opts {
-		_ = opt(gci)
+		opt(gci)
 	}
 
 	if gci.tokenClient == nil {

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+var DefaultAccessTokenMetadataKey = "X-Access-Token"
+
 // TODO (gamab): ID Token
 // TODO (gamab): Make Access Token optional?
 // TODO (gamab): Organization/Stack ID
@@ -16,6 +18,7 @@ import (
 // GrpcClientConfig holds the configuration for the gRPC client interceptor.
 type GrpcClientConfig struct {
 	// AccessTokenMetadataKey is the key used to store the access token in the outgoing context metadata.
+	// Defaults to "X-Access-Token".
 	AccessTokenMetadataKey string
 	// TokenClientConfig holds the configuration for the token exchange client.
 	// Not required if TokenClient is provided.
@@ -42,6 +45,10 @@ func WithTokenClientOption(tokenClient TokenExchanger) GrpcClientInterceptorOpti
 
 func NewGrpcClientInterceptor(cfg *GrpcClientConfig, opts ...GrpcClientInterceptorOption) (*GrpcClientInterceptor, error) {
 	gci := &GrpcClientInterceptor{cfg: cfg}
+
+	if gci.cfg.AccessTokenMetadataKey == "" {
+		gci.cfg.AccessTokenMetadataKey = DefaultAccessTokenMetadataKey
+	}
 
 	if gci.cfg.TokenRequest == nil {
 		return nil, fmt.Errorf("missing required token request: %w", ErrMissingConfig)

--- a/authn/grpc_client_interceptors_test.go
+++ b/authn/grpc_client_interceptors_test.go
@@ -1,0 +1,45 @@
+package authn
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+type FakeTokenExchanger struct {
+	token string
+}
+
+func (f *FakeTokenExchanger) Exchange(ctx context.Context, req TokenExchangeRequest) (*TokenExchangeResponse, error) {
+	return &TokenExchangeResponse{Token: f.token}, nil
+}
+
+func setupGrpcClientInterceptor(t *testing.T) (*GrpcClientInterceptor, *FakeTokenExchanger) {
+	tokenClient := &FakeTokenExchanger{token: "some-token"}
+
+	client, err := NewGrpcClientInterceptor(
+		&GrpcClientConfig{TokenRequest: &TokenExchangeRequest{Namespace: "some-namespace", Audiences: []string{"some-service"}}},
+		WithTokenClientOption(tokenClient),
+	)
+	require.NoError(t, err)
+
+	return client, tokenClient
+}
+
+func TestGrpcClientInterceptor_wrapContext(t *testing.T) {
+	gci, _ := setupGrpcClientInterceptor(t)
+
+	ctx, err := gci.wrapContext(context.Background())
+	require.NoError(t, err)
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok)
+	require.Len(t, md, 1)
+	mdAtKey := md.Get(DefaultAccessTokenMetadataKey)
+	require.Len(t, mdAtKey, 1)
+	token := mdAtKey[0]
+
+	require.Equal(t, token, "some-token")
+}


### PR DESCRIPTION
This PR adds a new grpc client interceptor that adds access tokens to the outgoing context of grpc calls.

Open question for later:
- how to handle missing ID tokens? Given for service communications it might be normal not to have a user involved. But there might be cases where the service wants to make requests on behalf of a user and in such cases a missing user might be an error.
