### PR TITLE
AuthN: Add id token to gRPC client interceptors

### DIFF
--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -22,16 +22,15 @@ type GrpcClientConfig struct {
 	// AccessTokenMetadataKey is the key used to store the access token in the outgoing context metadata.
 	// Defaults to "X-Access-Token".
 	AccessTokenMetadataKey string
+	// IDTokenMetadataKey is the key used to store the ID token in the outgoing context metadata.
+	// Not required if IDTokenExtractor is provided. Defaults to "X-Id-Token".
+	IDTokenMetadataKey string
 	// TokenClientConfig holds the configuration for the token exchange client.
 	// Not required if TokenClient is provided.
 	TokenClientConfig *TokenExchangeConfig
 	// TokenRequest is the token request to be used for token exchange.
 	// This assumes the token request is static and does not change.
 	TokenRequest *TokenExchangeRequest
-
-	// IDTokenMetadataKey is the key used to store the ID token in the outgoing context metadata.
-	// Defaults to "X-Id-Token".
-	IDTokenMetadataKey string
 }
 
 // GrpcClientInterceptor is a gRPC client interceptor that adds an access token to the outgoing context metadata.

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-var (
+const (
 	DefaultAccessTokenMetadataKey = "X-Access-Token"
 	DefaultIdTokenMetadataKey     = "X-Id-Token"
 )

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -130,12 +130,10 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 
 	md.Set(gci.cfg.AccessTokenMetadataKey, token.Token)
 
-	if len(gci.mdFns) > 0 {
-		for _, fn := range gci.mdFns {
-			md, err = fn(md)
-			if err != nil {
-				return ctx, err
-			}
+	for _, fn := range gci.mdFns {
+		md, err = fn(md)
+		if err != nil {
+			return ctx, err
 		}
 	}
 


### PR DESCRIPTION
This PR allows users to add id tokens to the grpc metadata in the outgoing context.

Additionally, to cover future usage, this PR allows adding additional decorators to the metadata.