### PR TITLE
AuthZ: Add namespace validation

### DIFF
--- a/authn/namespace.go
+++ b/authn/namespace.go
@@ -1,0 +1,19 @@
+package authn
+
+import "fmt"
+
+// NamespaceFormatter defines a function that formats a stack or organization ID
+// into the expected namespace format based on the deployment environment (Cloud/On-prem).
+// Example: stack-6481, org-12
+type NamespaceFormatter func(int64) string
+
+func CloudNamespaceFormatter(id int64) string {
+	return fmt.Sprintf("stack-%d", id)
+}
+
+func OnPremNamespaceFormatter(id int64) string {
+	if id == 1 {
+		return "default"
+	}
+	return fmt.Sprintf("org-%d", id)
+}

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -186,9 +186,7 @@ func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, 
 		return false, err
 	}
 
-	// Validate the namespace
-	ok := c.validateNamespace(req.Caller, req.StackID)
-	if !ok {
+	if !c.validateNamespace(req.Caller, req.StackID) {
 		return false, nil
 	}
 

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -32,6 +32,8 @@ var (
 	ErrReadPermission = status.Errorf(codes.PermissionDenied, "read permission failed")
 )
 
+const NamespaceStack = "stack"
+
 type CheckRequest struct {
 	Caller     authn.CallerAuthInfo
 	StackID    int64
@@ -173,6 +175,11 @@ func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, 
 	if err := req.Validate(); err != nil {
 		span.RecordError(err)
 		return false, err
+	}
+
+	// Validate the namespace
+	if !req.Caller.AccessTokenClaims.Rest.NamespaceMatches(fmt.Sprintf("%s-%d", NamespaceStack, req.StackID)) {
+		return false, nil
 	}
 
 	span.SetAttributes(attribute.String("service", req.Caller.AccessTokenClaims.Subject))

--- a/authz/multitenant_client_test.go
+++ b/authz/multitenant_client_test.go
@@ -376,24 +376,6 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "On behalf of, action check but wrong namespace",
-			req: CheckRequest{
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
-						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-13", DelegatedPermissions: []string{"dashboards:read"}},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
-						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
-				},
-				StackID: 12,
-				Action:  "dashboards:read",
-			},
-			want: false,
-		},
-		{
 			name: "On behalf of, user has the action on another resource",
 			req: CheckRequest{
 				Caller: authn.CallerAuthInfo{

--- a/authz/multitenant_client_test.go
+++ b/authz/multitenant_client_test.go
@@ -264,7 +264,10 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 			name: "Service does not have the action",
 			req: CheckRequest{
 				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Claims: &jwt.Claims{Subject: "service"}},
+					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+						Claims: &jwt.Claims{Subject: "service"},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12"},
+					},
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -272,12 +275,12 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "Service does not has the action",
+			name: "Service has the action",
 			req: CheckRequest{
 				Caller: authn.CallerAuthInfo{
 					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Permissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", Permissions: []string{"dashboards:read"}},
 					},
 				},
 				StackID: 12,
@@ -286,11 +289,28 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "Service has the action but in the wrong namespace",
+			req: CheckRequest{
+				Caller: authn.CallerAuthInfo{
+					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+						Claims: &jwt.Claims{Subject: "service"},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-13", Permissions: []string{"dashboards:read"}},
+					},
+				},
+				StackID: 12,
+				Action:  "dashboards:read",
+			},
+			want: false,
+		},
+		{
 			name: "On behalf of, service does not have the action",
 			req: CheckRequest{
 				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Claims: &jwt.Claims{Subject: "service"}},
-					IDTokenClaims:     &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
+					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+						Claims: &jwt.Claims{Subject: "service"},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12"},
+					},
+					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -303,7 +323,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: authn.CallerAuthInfo{
 					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
 					},
 					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
 				},
@@ -318,7 +338,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: authn.CallerAuthInfo{
 					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
 					},
 					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
 				},
@@ -329,12 +349,27 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "On behalf of, action check but wrong namespace",
+			req: CheckRequest{
+				Caller: authn.CallerAuthInfo{
+					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+						Claims: &jwt.Claims{Subject: "service"},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-13", DelegatedPermissions: []string{"dashboards:read"}},
+					},
+					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
+				},
+				StackID: 12,
+				Action:  "dashboards:read",
+			},
+			want: false,
+		},
+		{
 			name: "On behalf of, user has the action on another resource",
 			req: CheckRequest{
 				Caller: authn.CallerAuthInfo{
 					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
 					},
 					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
 				},
@@ -351,7 +386,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: authn.CallerAuthInfo{
 					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
 					},
 					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
 				},
@@ -368,7 +403,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: authn.CallerAuthInfo{
 					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
 					},
 					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Claims: &jwt.Claims{Subject: "user:1"}},
 				},


### PR DESCRIPTION
**PR changes:**

- Introduces a configurable namespace formatter, with implementations for onprem (org based namespaces) and cloud (stack based namespaces)
- Adds the namespace validation logic to the AuthZ client. 

**Benefits:**

- **Flexibility:** The authorization client can now easily adapt to different environments with varying namespace formats.
- **Security:**  Access control checks in other namespaces will result in forbidden access.

**Testing:**

- Unit tests have been updated to cover the new namespace formatters.
