### PR TITLE
AuthN: gRPC Client Interceptors - Add option to make access tokens optional

### DIFF
--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -77,7 +77,7 @@ func NewGrpcClientInterceptor(cfg *GrpcClientConfig, opts ...GrpcClientIntercept
 		gci.cfg.IDTokenMetadataKey = DefaultIdTokenMetadataKey
 	}
 
-	if gci.cfg.TokenRequest == nil {
+	if gci.cfg.TokenRequest == nil && !gci.cfg.DisableAccessToken {
 		return nil, fmt.Errorf("missing required token request: %w", ErrMissingConfig)
 	}
 
@@ -85,7 +85,7 @@ func NewGrpcClientInterceptor(cfg *GrpcClientConfig, opts ...GrpcClientIntercept
 		opt(gci)
 	}
 
-	if gci.tokenClient == nil {
+	if gci.tokenClient == nil && !gci.cfg.DisableAccessToken {
 		if gci.cfg.TokenClientConfig == nil {
 			return nil, fmt.Errorf("missing required token client config: %w", ErrMissingConfig)
 		}

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -16,7 +16,7 @@ const (
 // GrpcClientConfig holds the configuration for the gRPC client interceptor.
 type GrpcClientConfig struct {
 	// DisableAccessToken is a flag to disable the access token.
-	// Warning: Using this options means there won't be any servie authentication.
+	// Warning: Using this option means there won't be any service authentication.
 	DisableAccessToken bool
 	// AccessTokenMetadataKey is the key used to store the access token in the outgoing context metadata.
 	// Defaults to "X-Access-Token".

--- a/authn/grpc_client_interceptors_test.go
+++ b/authn/grpc_client_interceptors_test.go
@@ -64,9 +64,8 @@ func TestGrpcClientInterceptor_wrapContext(t *testing.T) {
 }
 
 func TestGrpcClientInterceptor_wrapContextNoAccessToken(t *testing.T) {
-	gci, _ := setupGrpcClientInterceptor(t)
-	// Disable access token
-	gci.cfg.DisableAccessToken = true
+	gci, err := NewGrpcClientInterceptor(&GrpcClientConfig{DisableAccessToken: true})
+	require.NoError(t, err)
 
 	type idKey struct{}
 
@@ -82,7 +81,7 @@ func TestGrpcClientInterceptor_wrapContextNoAccessToken(t *testing.T) {
 	// Add id_token to context
 	ctx := context.WithValue(context.Background(), idKey{}, "some-id-token")
 
-	ctx, err := gci.wrapContext(ctx)
+	ctx, err = gci.wrapContext(ctx)
 	require.NoError(t, err)
 
 	md, ok := metadata.FromOutgoingContext(ctx)


### PR DESCRIPTION
This PR adds an unsafe option to make access tokens options.
This is meant to be used on-prem while access tokens are not possible to use there.