### PR TITLE
AuthZ: LegacyClient - Add option to make access tokens optional

### DIFF
--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -45,7 +45,7 @@ type MultiTenantClientConfig struct {
 	// RemoteAddress is the address of the authz service. It should be in the format "host:port".
 	RemoteAddress string
 	// DisableAccessToken will disable the access token check.
-	// Warning: Using this option means there won't be any service authentication.
+	// Warning: Using this option means there won't be any service authorization.
 	DisableAccessToken bool
 }
 


### PR DESCRIPTION
This PR adds an unsafe option to make access tokens options.
This is meant to be used on-prem while access tokens are not possible to use there.