### PR TITLE
AuthN: Add gRPC authenticator

### DIFF
--- a/authn/caller_info.go
+++ b/authn/caller_info.go
@@ -5,6 +5,7 @@ import "context"
 type CallerAuthInfo struct {
 	IDTokenClaims     *Claims[IDTokenClaims]
 	AccessTokenClaims Claims[AccessTokenClaims]
+	StackID           int64
 }
 
 type CallerAuthInfoContextKey struct{}

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -1,0 +1,140 @@
+package authn
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/gogo/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	ErrorMissingMetadata    = status.Error(codes.Unauthenticated, "unauthenticated: no metadata found")
+	ErrorMissingIDToken     = status.Error(codes.Unauthenticated, "unauthenticated: missing id token")
+	ErrorMissingAccessToken = status.Error(codes.Unauthenticated, "unauthenticated: missing access token")
+	ErrorInvalidIDToken     = status.Error(codes.PermissionDenied, "unauthorized: invalid id token")
+	ErrorInvalidAccessToken = status.Error(codes.PermissionDenied, "unauthorized: invalid access token")
+)
+
+// GrpcAuthenticatorConfig holds the configuration for the gRPC authenticator.
+type GrpcAuthenticatorConfig struct {
+}
+
+// GrpcAuthenticator is a gRPC authenticator that authenticates incoming requests based on the access token and ID token.
+type GrpcAuthenticator struct {
+	atVerifier   Verifier[AccessTokenClaims]
+	idVerifier   Verifier[IDTokenClaims]
+	namespaceFmt NamespaceFormatter
+}
+
+func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context, error) {
+	callerInfo := CallerAuthInfo{}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return nil, ErrorMissingMetadata
+	}
+
+	at, ok := getFirstMetadataValue(md, DefaultAccessTokenMetadataKey)
+	if !ok {
+		return nil, ErrorMissingAccessToken
+	}
+
+	atClaims, err := ga.atVerifier.Verify(ctx, at)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %w", err, ErrorInvalidAccessToken)
+	}
+
+	callerInfo.AccessTokenClaims = *atClaims
+
+	return AddCallerAuthInfoToContext(ctx, callerInfo), nil
+}
+
+func (ga *GrpcAuthenticator) authenticateService(stackID int64, claims *Claims[AccessTokenClaims]) error {
+	expectedNamespace := ga.namespaceFmt(stackID)
+
+	// Allow access tokens with that has a wildcard namespace or a namespace matching this instance.
+	if !claims.Rest.NamespaceMatches(expectedNamespace) {
+		return fmt.Errorf("unexpected access token namespace: %s", claims.Rest.Namespace, ErrorInvalidAccessToken)
+	}
+
+	subject, err := parseSubject(claims.Subject)
+	if err != nil {
+		return fmt.Errorf("failed to parse access token subject %v", err, ErrorInvalidAccessToken)
+	}
+
+	if subject.namespace == namespaceAccessPolicy {
+		return fmt.Errorf("access token subject '%s' namespace is not allowed: %w", subject.namespace, ErrorInvalidAccessToken)
+	}
+
+	return nil
+}
+
+func getFirstMetadataValue(md metadata.MD, key string) (string, bool) {
+	values := md.Get(key)
+	if len(values) == 0 {
+		return "", false
+	}
+	if len(values[0]) == 0 {
+		return "", false
+	}
+
+	return values[0], true
+}
+
+// ------
+// Subject
+// FIXME: This is a duplicate of Grafana's identity namespaces and namespacedID. It should be moved to a shared package.
+// ------
+const (
+	namespaceUser           subjectNamespace = "user"
+	namespaceAPIKey         subjectNamespace = "api-key"
+	namespaceServiceAccount subjectNamespace = "service-account"
+	namespaceAnonymous      subjectNamespace = "anonymous"
+	namespaceRenderService  subjectNamespace = "render"
+	namespaceAccessPolicy   subjectNamespace = "access-policy"
+	namespaceProvisioning   subjectNamespace = "provisioning"
+	namespaceEmpty          subjectNamespace = ""
+)
+
+var (
+	ErrorInvalidSubject   = status.Error(codes.PermissionDenied, "unauthorized: invalid subject")
+	ErrorInvalidNamespace = status.Error(codes.PermissionDenied, "unauthorized: invalid namespace")
+)
+
+type subjectNamespace string
+
+func (n subjectNamespace) isValid() error {
+	switch n {
+	case namespaceUser, namespaceAPIKey, namespaceServiceAccount, namespaceAnonymous, namespaceRenderService, namespaceAccessPolicy, namespaceProvisioning, namespaceEmpty:
+		return nil
+	default:
+		return fmt.Errorf("invalid namespace %s: %w", n, ErrorInvalidNamespace)
+	}
+}
+
+type subject struct {
+	id        string           // Ex: 1234567890
+	namespace subjectNamespace // Ex: user, service-account, api-key
+}
+
+func parseSubject(str string) (subject, error) {
+	var subject subject
+
+	parts := strings.Split(str, ":")
+	if len(parts) != 2 {
+		return subject, fmt.Errorf("expected namespace id to have 2 parts: %w", ErrorInvalidSubject)
+	}
+
+	subject.id = parts[1]
+	subject.namespace = subjectNamespace(parts[0])
+
+	err := subject.namespace.isValid()
+	if err != nil {
+		return subject, err
+	}
+
+	return subject, nil
+}

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -160,8 +160,8 @@ const (
 )
 
 var (
-	ErrorInvalidSubject   = status.Error(codes.PermissionDenied, "unauthorized: invalid subject")
-	ErrorInvalidNamespace = status.Error(codes.PermissionDenied, "unauthorized: invalid namespace")
+	ErrorInvalidSubject     = status.Error(codes.PermissionDenied, "unauthorized: invalid subject")
+	ErrorInvalidSubjectType = status.Error(codes.PermissionDenied, "unauthorized: invalid subject type")
 )
 
 type subjectType string
@@ -171,7 +171,7 @@ func (n subjectType) isValid() error {
 	case typeUser, typeAPIKey, typeServiceAccount, typeAnonymous, typeRenderService, typeAccessPolicy, typeProvisioning, typeEmpty:
 		return nil
 	default:
-		return fmt.Errorf("invalid namespace %s: %w", n, ErrorInvalidNamespace)
+		return fmt.Errorf("invalid type %s: %w", n, ErrorInvalidSubjectType)
 	}
 }
 
@@ -185,7 +185,7 @@ func parseSubject(str string) (subject, error) {
 
 	parts := strings.Split(str, ":")
 	if len(parts) != 2 {
-		return subject, fmt.Errorf("expected namespace id to have 2 parts: %w", ErrorInvalidSubject)
+		return subject, fmt.Errorf("expected subject to have 2 parts: %w", ErrorInvalidSubject)
 	}
 
 	subject.ID = parts[1]

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -22,6 +22,7 @@ var (
 
 // TODO (gamab) - Constructor
 // TODO (gamab) - ID token should be optional
+// TODO (gamab) - Add unsafe option to make access tokens optional as well (on-prem support)
 // TODO (gamab) - Metadata key should be configurable
 // TODO (gamab) - StackID extract should be configurable - could come from the metadata, path, id token.
 

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -97,7 +97,7 @@ func (ga *GrpcAuthenticator) authenticateService(ctx context.Context, stackID in
 	}
 
 	if subject.Type != typeAccessPolicy {
-		return nil, fmt.Errorf("access token subject '%s' namespace is not allowed: %w", subject.Type, ErrorInvalidAccessToken)
+		return nil, fmt.Errorf("access token subject '%s' type is not allowed: %w", subject.Type, ErrorInvalidAccessToken)
 	}
 
 	return claims, nil
@@ -126,7 +126,7 @@ func (ga *GrpcAuthenticator) authenticateUser(ctx context.Context, stackID int64
 	}
 
 	if subject.Type != typeUser && subject.Type != typeServiceAccount {
-		return nil, fmt.Errorf("id token subject '%s' namespace is not allowed: %w", subject.Type, ErrorInvalidIDToken)
+		return nil, fmt.Errorf("id token subject '%s' type is not allowed: %w", subject.Type, ErrorInvalidIDToken)
 	}
 
 	return claims, nil

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -20,7 +20,7 @@ var (
 	ErrorInvalidAccessToken = status.Error(codes.PermissionDenied, "unauthorized: invalid access token")
 )
 
-// TODO (gamab) - Constructor
+// TODO (gamab) - Constructor w/ config options
 // TODO (gamab) - ID token should be optional
 // TODO (gamab) - Add unsafe option to make access tokens optional as well (on-prem support)
 // TODO (gamab) - Metadata key should be configurable

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -93,11 +93,11 @@ func (ga *GrpcAuthenticator) authenticateService(ctx context.Context, stackID in
 
 	subject, err := parseSubject(claims.Subject)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse access token subject - %v: %w", err, ErrorInvalidAccessToken)
+		return nil, err
 	}
 
 	if subject.Type != typeAccessPolicy {
-		return nil, fmt.Errorf("access token subject '%s' type is not allowed: %w", subject.Type, ErrorInvalidAccessToken)
+		return nil, fmt.Errorf("access token subject '%s' type is not allowed: %w", subject.Type, ErrorInvalidSubjectType)
 	}
 
 	return claims, nil
@@ -122,11 +122,11 @@ func (ga *GrpcAuthenticator) authenticateUser(ctx context.Context, stackID int64
 
 	subject, err := parseSubject(claims.Subject)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse id token subject - %v: %w", err, ErrorInvalidIDToken)
+		return nil, err
 	}
 
 	if subject.Type != typeUser && subject.Type != typeServiceAccount {
-		return nil, fmt.Errorf("id token subject '%s' type is not allowed: %w", subject.Type, ErrorInvalidIDToken)
+		return nil, fmt.Errorf("id token subject '%s' type is not allowed: %w", subject.Type, ErrorInvalidSubjectType)
 	}
 
 	return claims, nil

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -19,9 +19,10 @@ var (
 	ErrorInvalidAccessToken = status.Error(codes.PermissionDenied, "unauthorized: invalid access token")
 )
 
+// TODO (gamab) - Constructor
 // TODO (gamab) - ID token should be optional
 // TODO (gamab) - Metadata key should be configurable
-// TODO (gamab) - StackID should extract should be configurable - could come from the metadata, path, id token.
+// TODO (gamab) - StackID extract should be configurable - could come from the metadata, path, id token.
 
 // GrpcAuthenticatorConfig holds the configuration for the gRPC authenticator.
 type GrpcAuthenticatorConfig struct {
@@ -42,7 +43,7 @@ func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context,
 		return nil, ErrorMissingMetadata
 	}
 
-	// TODO (gamab) - StackID should extract should be configurable - could come from the metadata, path, id token.
+	// TODO (gamab) - StackID extract should be configurable - could come from the metadata, path, id token.
 	stackID, ok := getFirstMetadataValue(md, DefaultStackIDMetadataKey)
 	if !ok {
 		return nil, fmt.Errorf("missing stack ID: %w", ErrorMissingMetadata)
@@ -97,7 +98,7 @@ func (ga *GrpcAuthenticator) authenticateService(ctx context.Context, stackID in
 		return nil, fmt.Errorf("failed to parse access token subject - %v: %w", err, ErrorInvalidAccessToken)
 	}
 
-	if subject.namespace == namespaceAccessPolicy {
+	if subject.namespace != namespaceAccessPolicy {
 		return nil, fmt.Errorf("access token subject '%s' namespace is not allowed: %w", subject.namespace, ErrorInvalidAccessToken)
 	}
 

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -93,7 +93,7 @@ func (ga *GrpcAuthenticator) authenticateService(ctx context.Context, stackID in
 
 	subject, err := parseSubject(claims.Subject)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("access token subject '%s' is not valid: %w", claims.Subject, err)
 	}
 
 	if subject.Type != typeAccessPolicy {
@@ -122,7 +122,7 @@ func (ga *GrpcAuthenticator) authenticateUser(ctx context.Context, stackID int64
 
 	subject, err := parseSubject(claims.Subject)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("id token subject '%s' is not valid: %w", claims.Subject, err)
 	}
 
 	if subject.Type != typeUser && subject.Type != typeServiceAccount {

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -36,6 +36,7 @@ type GrpcAuthenticator struct {
 	namespaceFmt NamespaceFormatter
 }
 
+// Authenticate authenticates the incoming request based on the access token and ID token, and returns the context with the caller information.
 func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context, error) {
 	callerInfo := CallerAuthInfo{}
 

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -74,7 +74,7 @@ func TestGrpcAuthenticator_authenticateServie(t *testing.T) {
 			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
 			initAccessToken: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
-					Claims: &jwt.Claims{Subject: string(namespaceAPIKey) + ":3"},
+					Claims: &jwt.Claims{Subject: string(typeAPIKey) + ":3"},
 					Rest:   AccessTokenClaims{Namespace: "stack-12"},
 				}
 			},
@@ -85,12 +85,12 @@ func TestGrpcAuthenticator_authenticateServie(t *testing.T) {
 			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
 			initAccessToken: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
-					Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
 					Rest:   AccessTokenClaims{Namespace: "stack-12"},
 				}
 			},
 			want: &Claims[AccessTokenClaims]{
-				Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+				Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
 				Rest:   AccessTokenClaims{Namespace: "stack-12"},
 			},
 		},
@@ -99,12 +99,12 @@ func TestGrpcAuthenticator_authenticateServie(t *testing.T) {
 			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
 			initAccessToken: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
-					Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
 					Rest:   AccessTokenClaims{Namespace: "*"},
 				}
 			},
 			want: &Claims[AccessTokenClaims]{
-				Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+				Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
 				Rest:   AccessTokenClaims{Namespace: "*"},
 			},
 		},
@@ -174,7 +174,7 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 			md:   metadata.Pairs(DefaultIdTokenMetadataKey, "id-token"),
 			initIDToken: func(env *testEnv) {
 				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
-					Claims: &jwt.Claims{Subject: string(namespaceAPIKey) + ":3"},
+					Claims: &jwt.Claims{Subject: string(typeAPIKey) + ":3"},
 					Rest:   IDTokenClaims{Namespace: "stack-12"},
 				}
 			},
@@ -185,12 +185,12 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 			md:   metadata.Pairs(DefaultIdTokenMetadataKey, "id-token"),
 			initIDToken: func(env *testEnv) {
 				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
-					Claims: &jwt.Claims{Subject: string(namespaceUser) + ":3"},
+					Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
 					Rest:   IDTokenClaims{Namespace: "stack-12"},
 				}
 			},
 			want: &Claims[IDTokenClaims]{
-				Claims: &jwt.Claims{Subject: string(namespaceUser) + ":3"},
+				Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
 				Rest:   IDTokenClaims{Namespace: "stack-12"},
 			},
 		},

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -166,7 +166,7 @@ func TestGrpcAuthenticator_authenticateService(t *testing.T) {
 					Rest:   AccessTokenClaims{Namespace: "stack-12"},
 				}
 			},
-			wantErr: ErrorInvalidAccessToken,
+			wantErr: ErrorInvalidSubject,
 		},
 		{
 			name: "invalid subject type",
@@ -177,7 +177,7 @@ func TestGrpcAuthenticator_authenticateService(t *testing.T) {
 					Rest:   AccessTokenClaims{Namespace: "stack-12"},
 				}
 			},
-			wantErr: ErrorInvalidAccessToken,
+			wantErr: ErrorInvalidSubjectType,
 		},
 		{
 			name: "valid access token",
@@ -266,7 +266,7 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 					Rest:   IDTokenClaims{Namespace: "stack-12"},
 				}
 			},
-			wantErr: ErrorInvalidIDToken,
+			wantErr: ErrorInvalidSubject,
 		},
 		{
 			name: "invalid subject type",
@@ -277,7 +277,7 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 					Rest:   IDTokenClaims{Namespace: "stack-12"},
 				}
 			},
-			wantErr: ErrorInvalidIDToken,
+			wantErr: ErrorInvalidSubjectType,
 		},
 		{
 			name: "valid id token",

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -1,0 +1,245 @@
+package authn
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+type testEnv struct {
+	authenticator *GrpcAuthenticator
+	atVerifier    *fakeAccessTokenVerifier
+	idVerifier    *fakeIDTokenVerifier
+}
+
+func setupGrpcAuthenticator(t *testing.T) *testEnv {
+	env := &testEnv{
+		atVerifier: &fakeAccessTokenVerifier{},
+		idVerifier: &fakeIDTokenVerifier{},
+	}
+	env.authenticator = &GrpcAuthenticator{
+		atVerifier:   env.atVerifier,
+		idVerifier:   env.idVerifier,
+		namespaceFmt: CloudNamespaceFormatter,
+	}
+
+	return env
+}
+
+func TestGrpcAuthenticator_authenticateServie(t *testing.T) {
+	tests := []struct {
+		name            string
+		md              metadata.MD
+		initAccessToken initAccessTokenVerifierFake
+		want            *Claims[AccessTokenClaims]
+		wantErr         error
+	}{
+		{
+			name:    "missing access token",
+			md:      metadata.Pairs(),
+			wantErr: ErrorMissingAccessToken,
+		},
+		{
+			name:    "invalid access token",
+			md:      metadata.Pairs(DefaultAccessTokenMetadataKey, "invalid-access-token"),
+			wantErr: ErrorInvalidAccessToken,
+		},
+		{
+			name: "invalid namespace",
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
+			initAccessToken: func(env *testEnv) {
+				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
+					Rest: AccessTokenClaims{Namespace: "stack-13"},
+				}
+			},
+			wantErr: ErrorInvalidAccessToken,
+		},
+		{
+			name: "invalid subject",
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
+			initAccessToken: func(env *testEnv) {
+				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
+					Claims: &jwt.Claims{Subject: "invalid-subject"},
+					Rest:   AccessTokenClaims{Namespace: "stack-12"},
+				}
+			},
+			wantErr: ErrorInvalidAccessToken,
+		},
+		{
+			name: "invalid subject type",
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
+			initAccessToken: func(env *testEnv) {
+				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
+					Claims: &jwt.Claims{Subject: string(namespaceAPIKey) + ":3"},
+					Rest:   AccessTokenClaims{Namespace: "stack-12"},
+				}
+			},
+			wantErr: ErrorInvalidAccessToken,
+		},
+		{
+			name: "valid access token",
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
+			initAccessToken: func(env *testEnv) {
+				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
+					Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+					Rest:   AccessTokenClaims{Namespace: "stack-12"},
+				}
+			},
+			want: &Claims[AccessTokenClaims]{
+				Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+				Rest:   AccessTokenClaims{Namespace: "stack-12"},
+			},
+		},
+		{
+			name: "valid access token with wildcard namespace",
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
+			initAccessToken: func(env *testEnv) {
+				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
+					Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+					Rest:   AccessTokenClaims{Namespace: "*"},
+				}
+			},
+			want: &Claims[AccessTokenClaims]{
+				Claims: &jwt.Claims{Subject: string(namespaceAccessPolicy) + ":3"},
+				Rest:   AccessTokenClaims{Namespace: "*"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := setupGrpcAuthenticator(t)
+			if tt.initAccessToken != nil {
+				tt.initAccessToken(env)
+			}
+
+			got, err := env.authenticator.authenticateService(context.Background(), 12, tt.md)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, *tt.want.Claims, *got.Claims)
+			require.Equal(t, tt.want.Rest, got.Rest)
+		})
+	}
+}
+
+func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		md          metadata.MD
+		initIDToken initIDTokenVerifierFake
+		want        *Claims[IDTokenClaims]
+		wantErr     error
+	}{
+		{
+			name:    "missing id token",
+			md:      metadata.Pairs(),
+			wantErr: ErrorMissingIDToken,
+		},
+		{
+			name:    "invalid id token",
+			md:      metadata.Pairs(DefaultIdTokenMetadataKey, "invalid-id-token"),
+			wantErr: ErrorInvalidIDToken,
+		},
+		{
+			name: "invalid namespace",
+			md:   metadata.Pairs(DefaultIdTokenMetadataKey, "id-token"),
+			initIDToken: func(env *testEnv) {
+				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
+					Rest: IDTokenClaims{Namespace: "stack-13"},
+				}
+			},
+			wantErr: ErrorInvalidIDToken,
+		},
+		{
+			name: "invalid subject",
+			md:   metadata.Pairs(DefaultIdTokenMetadataKey, "id-token"),
+			initIDToken: func(env *testEnv) {
+				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
+					Claims: &jwt.Claims{Subject: "invalid-subject"},
+					Rest:   IDTokenClaims{Namespace: "stack-12"},
+				}
+			},
+			wantErr: ErrorInvalidIDToken,
+		},
+		{
+			name: "invalid subject type",
+			md:   metadata.Pairs(DefaultIdTokenMetadataKey, "id-token"),
+			initIDToken: func(env *testEnv) {
+				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
+					Claims: &jwt.Claims{Subject: string(namespaceAPIKey) + ":3"},
+					Rest:   IDTokenClaims{Namespace: "stack-12"},
+				}
+			},
+			wantErr: ErrorInvalidIDToken,
+		},
+		{
+			name: "valid id token",
+			md:   metadata.Pairs(DefaultIdTokenMetadataKey, "id-token"),
+			initIDToken: func(env *testEnv) {
+				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
+					Claims: &jwt.Claims{Subject: string(namespaceUser) + ":3"},
+					Rest:   IDTokenClaims{Namespace: "stack-12"},
+				}
+			},
+			want: &Claims[IDTokenClaims]{
+				Claims: &jwt.Claims{Subject: string(namespaceUser) + ":3"},
+				Rest:   IDTokenClaims{Namespace: "stack-12"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := setupGrpcAuthenticator(t)
+			if tt.initIDToken != nil {
+				tt.initIDToken(env)
+			}
+
+			got, err := env.authenticator.authenticateUser(context.Background(), 12, tt.md)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, *tt.want.Claims, *got.Claims)
+			require.Equal(t, tt.want.Rest, got.Rest)
+		})
+	}
+}
+
+type initIDTokenVerifierFake func(*testEnv)
+
+type fakeIDTokenVerifier struct {
+	expectedClaims *Claims[IDTokenClaims]
+	expectedError  error
+}
+
+func (f *fakeIDTokenVerifier) Verify(ctx context.Context, token string) (*Claims[IDTokenClaims], error) {
+	if token != "id-token" {
+		return nil, fmt.Errorf("invalid id token")
+	}
+	return f.expectedClaims, f.expectedError
+}
+
+type initAccessTokenVerifierFake func(*testEnv)
+
+type fakeAccessTokenVerifier struct {
+	expectedClaims *Claims[AccessTokenClaims]
+	expectedError  error
+}
+
+func (f *fakeAccessTokenVerifier) Verify(ctx context.Context, token string) (*Claims[AccessTokenClaims], error) {
+	if token != "access-token" {
+		return nil, fmt.Errorf("invalid access token")
+	}
+	return f.expectedClaims, f.expectedError
+}


### PR DESCRIPTION
This PR introduces a new gRPC authenticator that verifies incoming requests based on access and ID tokens.

**Key changes:**

* Adds `GrpcAuthenticator` that performs authentication based on access and ID tokens present in the request metadata.
* Verifies the tokens using existing `Verifier` implementations for both access and ID tokens.
* Extracts the stack ID from the request metadata and ensures both tokens belong to the expected namespace.
* Validates the token subject types, allowing only specific types for access and ID tokens.
* Returns a context enriched with caller information upon successful authentication.

**TODOs:**

* Implement constructor for `GrpcAuthenticator`.
* Make ID token verification optional.
* Allow configuration of metadata keys for tokens and stack ID.
* Implement configurable stack ID extraction from various sources (metadata, path, ID token).

**Next Steps:**

* Integrate the `GrpcAuthenticator` into the gRPC server pipeline.
* Configure the authenticator with appropriate verifiers and customization options.
* Update documentation and examples to showcase the new authentication mechanism.

This change enhances the security of our gRPC services by providing a robust and flexible authentication mechanism.