### PR TITLE
Authn: Add DisplayName to ID Token Claims

### DIFF
--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -16,6 +16,8 @@ type IDTokenClaims struct {
 	Username string `json:"username"`
 	// UID is the unique ID of the user (UID attribute)
 	UID string `json:"uid"`
+	// Name of the user (name attribute)
+	Name string `json:"name"`
 }
 
 func (c IDTokenClaims) NamespaceMatches(namespace string) bool {

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -16,8 +16,8 @@ type IDTokenClaims struct {
 	Username string `json:"username"`
 	// UID is the unique ID of the user (UID attribute)
 	UID string `json:"uid"`
-	// Name of the user (name attribute)
-	Name string `json:"name"`
+	// Display Name of the user (name attribute if it is set, otherwise the login or email)
+	DisplayName string `json:"name"`
 }
 
 func (c IDTokenClaims) NamespaceMatches(namespace string) bool {


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/pull/90992

Adds `DisplayName` as a field called `name` to the ID Token claims.