### PR TITLE
AuthN: Make gRPC authenticator configurable

### DIFF
--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -20,21 +20,98 @@ var (
 	ErrorInvalidAccessToken = status.Error(codes.PermissionDenied, "unauthorized: invalid access token")
 )
 
-// TODO (gamab) - Constructor w/ config options
-// TODO (gamab) - ID token should be optional
 // TODO (gamab) - Add unsafe option to make access tokens optional as well (on-prem support)
-// TODO (gamab) - Metadata key should be configurable
 // TODO (gamab) - StackID extract should be configurable - could come from the metadata, path, id token.
+
+// GrpcAuthenticatorOptions
+type GrpcAuthenticatorOption func(*GrpcAuthenticator)
 
 // GrpcAuthenticatorConfig holds the configuration for the gRPC authenticator.
 type GrpcAuthenticatorConfig struct {
+	// AccessTokenMetadataKey is the key used to store the access token in the outgoing context metadata.
+	// Defaults to "X-Access-Token".
+	AccessTokenMetadataKey string
+	// IDTokenMetadataKey is the key used to store the ID token in the outgoing context metadata.
+	// Not required if IDTokenExtractor is provided. Defaults to "X-Id-Token".
+	IDTokenMetadataKey string
+	// StackIDMetadataKey is the key used to store the stack ID in the outgoing context metadata.
+	// Defaults to "X-Stack-Id".
+	StackIDMetadataKey string
+
+	// KeyRetrieverConfig holds the configuration for the key retriever.
+	// Ignored if KeyRetrieverOption is provided.
+	KeyRetrieverConfig KeyRetrieverConfig
+	// VerifierConfig holds the configuration for the token verifiers.
+	VerifierConfig VerifierConfig
+
+	// idTokenAuthEnabled is a flag to enable ID token authentication.
+	// If disabled, only access token authentication is performed.
+	idTokenAuthEnabled bool
+	// idTokenAuthRequired is a flag to require the ID token for authentication.
+	// If required is false, the ID token is optional for authentication
+	idTokenAuthRequired bool
 }
 
 // GrpcAuthenticator is a gRPC authenticator that authenticates incoming requests based on the access token and ID token.
 type GrpcAuthenticator struct {
+	cfg          *GrpcAuthenticatorConfig
+	keyRetriever KeyRetriever
 	atVerifier   Verifier[AccessTokenClaims]
 	idVerifier   Verifier[IDTokenClaims]
 	namespaceFmt NamespaceFormatter
+}
+
+func WithKeyRetrieverOption(kr KeyRetriever) GrpcAuthenticatorOption {
+	return func(ga *GrpcAuthenticator) {
+		ga.keyRetriever = kr
+	}
+}
+
+// WithIDTokenAuthOption is a flag to enable ID token authentication.
+// If required is true, the ID token is required for authentication.
+func WithIDTokenAuthOption(required bool) GrpcAuthenticatorOption {
+	return func(ga *GrpcAuthenticator) {
+		ga.cfg.idTokenAuthEnabled = true
+		ga.cfg.idTokenAuthRequired = required
+	}
+}
+
+func setDefaultMetadataKeys(cfg *GrpcAuthenticatorConfig) {
+	if cfg.AccessTokenMetadataKey == "" {
+		cfg.AccessTokenMetadataKey = DefaultAccessTokenMetadataKey
+	}
+	if cfg.IDTokenMetadataKey == "" {
+		cfg.IDTokenMetadataKey = DefaultIdTokenMetadataKey
+	}
+	if cfg.StackIDMetadataKey == "" {
+		cfg.StackIDMetadataKey = DefaultStackIDMetadataKey
+	}
+}
+
+func NewGrpcAuthenticator(cfg *GrpcAuthenticatorConfig, opts ...GrpcAuthenticatorOption) (*GrpcAuthenticator, error) {
+	setDefaultMetadataKeys(cfg)
+
+	ga := &GrpcAuthenticator{cfg: cfg}
+	for _, opt := range opts {
+		opt(ga)
+	}
+
+	if ga.keyRetriever == nil {
+		if cfg.KeyRetrieverConfig.SigningKeysURL == "" {
+			return nil, fmt.Errorf("missing signing keys URL: %w", ErrMissingConfig)
+		}
+
+		kr := NewKeyRetriever(cfg.KeyRetrieverConfig)
+		ga.keyRetriever = kr
+	}
+
+	ga.atVerifier = NewAccessTokenVerifier(cfg.VerifierConfig, ga.keyRetriever)
+
+	if ga.cfg.idTokenAuthEnabled {
+		ga.idVerifier = NewIDTokenVerifier(cfg.VerifierConfig, ga.keyRetriever)
+	}
+
+	return ga, nil
 }
 
 // Authenticate authenticates the incoming request based on the access token and ID token, and returns the context with the caller information.
@@ -47,7 +124,7 @@ func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context,
 	}
 
 	// TODO (gamab) - StackID extract should be configurable - could come from the metadata, path, id token.
-	stackID, ok := getFirstMetadataValue(md, DefaultStackIDMetadataKey)
+	stackID, ok := getFirstMetadataValue(md, ga.cfg.StackIDMetadataKey)
 	if !ok {
 		return nil, fmt.Errorf("missing stack ID: %w", ErrorMissingMetadata)
 	}
@@ -63,18 +140,19 @@ func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context,
 	}
 	callerInfo.AccessTokenClaims = *atClaims
 
-	idClaims, err := ga.authenticateUser(ctx, stackIDInt, md)
-	if err != nil {
-		// TODO (gamab): Handle id token optionality
-		return nil, err
+	if ga.cfg.idTokenAuthEnabled {
+		idClaims, err := ga.authenticateUser(ctx, stackIDInt, md)
+		if err != nil {
+			return nil, err
+		}
+		callerInfo.IDTokenClaims = idClaims
 	}
-	callerInfo.IDTokenClaims = idClaims
 
 	return AddCallerAuthInfoToContext(ctx, callerInfo), nil
 }
 
 func (ga *GrpcAuthenticator) authenticateService(ctx context.Context, stackID int64, md metadata.MD) (*Claims[AccessTokenClaims], error) {
-	at, ok := getFirstMetadataValue(md, DefaultAccessTokenMetadataKey)
+	at, ok := getFirstMetadataValue(md, ga.cfg.AccessTokenMetadataKey)
 	if !ok {
 		return nil, ErrorMissingAccessToken
 	}
@@ -104,9 +182,12 @@ func (ga *GrpcAuthenticator) authenticateService(ctx context.Context, stackID in
 }
 
 func (ga *GrpcAuthenticator) authenticateUser(ctx context.Context, stackID int64, md metadata.MD) (*Claims[IDTokenClaims], error) {
-	id, ok := getFirstMetadataValue(md, DefaultIdTokenMetadataKey)
+	id, ok := getFirstMetadataValue(md, ga.cfg.IDTokenMetadataKey)
 	if !ok {
-		return nil, ErrorMissingIDToken
+		if ga.cfg.idTokenAuthRequired {
+			return nil, ErrorMissingIDToken
+		}
+		return nil, nil
 	}
 
 	claims, err := ga.idVerifier.Verify(ctx, id)

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -28,13 +28,13 @@ type GrpcAuthenticatorOption func(*GrpcAuthenticator)
 
 // GrpcAuthenticatorConfig holds the configuration for the gRPC authenticator.
 type GrpcAuthenticatorConfig struct {
-	// AccessTokenMetadataKey is the key used to store the access token in the outgoing context metadata.
+	// AccessTokenMetadataKey is the key used to retrieve the access token from the incoming metadata.
 	// Defaults to "X-Access-Token".
 	AccessTokenMetadataKey string
-	// IDTokenMetadataKey is the key used to store the ID token in the outgoing context metadata.
-	// Not required if IDTokenExtractor is provided. Defaults to "X-Id-Token".
+	// IDTokenMetadataKey is the key used to retrieve the ID token from the incoming metadata.
+	// Defaults to "X-Id-Token".
 	IDTokenMetadataKey string
-	// StackIDMetadataKey is the key used to store the stack ID in the outgoing context metadata.
+	// StackIDMetadataKey is the key used to retrieve the stack ID from the incoming metadata.
 	// Defaults to "X-Stack-Id".
 	StackIDMetadataKey string
 

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -49,12 +49,12 @@ func TestGrpcAuthenticator_NewGrpcAuthenticator(t *testing.T) {
 		require.NotNil(t, ga)
 		require.NotNil(t, ga.keyRetriever)
 		require.NotNil(t, ga.atVerifier)
-		// ID token authentication is disabled by default
-		require.Nil(t, ga.idVerifier)
 		// Config has default metadata keys
 		require.Equal(t, DefaultAccessTokenMetadataKey, ga.cfg.AccessTokenMetadataKey)
 		require.Equal(t, DefaultIdTokenMetadataKey, ga.cfg.IDTokenMetadataKey)
 		require.Equal(t, DefaultStackIDMetadataKey, ga.cfg.StackIDMetadataKey)
+		// ID token authentication is disabled by default
+		require.Nil(t, ga.idVerifier)
 	})
 	t.Run("initialize authenticator with id token option", func(t *testing.T) {
 		ga, err := NewGrpcAuthenticator(
@@ -63,14 +63,8 @@ func TestGrpcAuthenticator_NewGrpcAuthenticator(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NotNil(t, ga)
-		require.NotNil(t, ga.keyRetriever)
-		require.NotNil(t, ga.atVerifier)
-		require.NotNil(t, ga.idVerifier)
-		// Config has default metadata keys
-		require.Equal(t, DefaultAccessTokenMetadataKey, ga.cfg.AccessTokenMetadataKey)
-		require.Equal(t, DefaultIdTokenMetadataKey, ga.cfg.IDTokenMetadataKey)
-		require.Equal(t, DefaultStackIDMetadataKey, ga.cfg.StackIDMetadataKey)
 		// ID token authentication is enabled
+		require.NotNil(t, ga.idVerifier)
 		require.True(t, ga.cfg.idTokenAuthEnabled)
 		require.True(t, ga.cfg.idTokenAuthRequired)
 	})

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -37,7 +37,6 @@ func setupGrpcAuthenticator() *testEnv {
 func TestGrpcAuthenticator_NewGrpcAuthenticator(t *testing.T) {
 	t.Run("should return error when missing signing keys URL", func(t *testing.T) {
 		ga, err := NewGrpcAuthenticator(&GrpcAuthenticatorConfig{})
-		require.Error(t, err)
 		require.ErrorIs(t, err, ErrMissingConfig)
 		require.Nil(t, ga)
 	})


### PR DESCRIPTION
This PR makes the gRPC authenticator configurable.

It adds a constructor to the gRPC Authenticator with configuration and options.

One of the option is to make id tokens optional or required.