### PR TITLE
AuthN: gRPC authenticator option to disable access tokens

### DIFF
--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -79,7 +79,7 @@ func WithIDTokenAuthOption(required bool) GrpcAuthenticatorOption {
 	}
 }
 
-// WithDisableAccessTokenAuthOption is a flag to disable access token authentication.
+// WithDisableAccessTokenAuthOption is an option to disable access token authentication.
 // Warning: Using this option means there won't be any service authentication.
 func WithDisableAccessTokenAuthOption() GrpcAuthenticatorOption {
 	return func(ga *GrpcAuthenticator) {

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -44,8 +44,7 @@ type GrpcAuthenticatorConfig struct {
 	VerifierConfig VerifierConfig
 
 	// accessTokenAuthEnabled is a flag to enable access token authentication.
-	// If disabled, only ID token authentication is performed.
-	// Warning: Using this option means there won't be any service authentication.
+	// If disabled, only ID token authentication is performed. Defaults to true.
 	accessTokenAuthEnabled bool
 	// idTokenAuthEnabled is a flag to enable ID token authentication.
 	// If disabled, only access token authentication is performed.


### PR DESCRIPTION
This PR adds an unsafe option to make access tokens optionals.
This is meant to be used on-prem while access tokens are not possible to use there.