### PR TITLE
AuthNZ: Revert logic on access token disabling option

### DIFF
--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -86,7 +86,7 @@ func WithDisableAccessTokenAuthOption() GrpcAuthenticatorOption {
 	}
 }
 
-func setCfgDefaults(cfg *GrpcAuthenticatorConfig) {
+func setGrpcAuthenticatorCfgDefaults(cfg *GrpcAuthenticatorConfig) {
 	if cfg.AccessTokenMetadataKey == "" {
 		cfg.AccessTokenMetadataKey = DefaultAccessTokenMetadataKey
 	}
@@ -100,7 +100,7 @@ func setCfgDefaults(cfg *GrpcAuthenticatorConfig) {
 }
 
 func NewGrpcAuthenticator(cfg *GrpcAuthenticatorConfig, opts ...GrpcAuthenticatorOption) (*GrpcAuthenticator, error) {
-	setCfgDefaults(cfg)
+	setGrpcAuthenticatorCfgDefaults(cfg)
 
 	ga := &GrpcAuthenticator{cfg: cfg}
 	for _, opt := range opts {

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -29,7 +29,7 @@ func setupGrpcAuthenticator() *testEnv {
 		idVerifier:   env.idVerifier,
 		namespaceFmt: CloudNamespaceFormatter,
 	}
-	setCfgDefaults(env.authenticator.cfg)
+	setGrpcAuthenticatorCfgDefaults(env.authenticator.cfg)
 
 	return env
 }

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -84,6 +84,8 @@ func WithMetadataExtractorOption(extractors ...ContextMetadataExtractor) GrpcCli
 	}
 }
 
+// WithDisableAccessTokenOption is an option to disable access token authentication.
+// Warning: Using this option means there won't be any service authentication.
 func WithDisableAccessTokenOption() GrpcClientInterceptorOption {
 	return func(gci *GrpcClientInterceptor) {
 		gci.cfg.accessTokenAuthEnabled = false

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -16,9 +16,6 @@ const (
 
 // GrpcClientConfig holds the configuration for the gRPC client interceptor.
 type GrpcClientConfig struct {
-	// DisableAccessToken is a flag to disable the access token.
-	// Warning: Using this option means there won't be any service authentication.
-	DisableAccessToken bool
 	// AccessTokenMetadataKey is the key used to store the access token in the outgoing context metadata.
 	// Defaults to "X-Access-Token".
 	AccessTokenMetadataKey string
@@ -34,6 +31,10 @@ type GrpcClientConfig struct {
 	// TokenRequest is the token request to be used for token exchange.
 	// This assumes the token request is static and does not change.
 	TokenRequest *TokenExchangeRequest
+
+	// accessTokenAuthEnabled is a flag to enable access token authentication.
+	// If disabled, no service authentication will be performed. Defaults to true.
+	accessTokenAuthEnabled bool
 }
 
 // GrpcClientInterceptor is a gRPC client interceptor that adds an access token to the outgoing context metadata.
@@ -83,28 +84,38 @@ func WithMetadataExtractorOption(extractors ...ContextMetadataExtractor) GrpcCli
 	}
 }
 
+func WithDisableAccessTokenOption() GrpcClientInterceptorOption {
+	return func(gci *GrpcClientInterceptor) {
+		gci.cfg.accessTokenAuthEnabled = false
+	}
+}
+
+func setGrpcClientCfgDefaults(cfg *GrpcClientConfig) {
+	if cfg.AccessTokenMetadataKey == "" {
+		cfg.AccessTokenMetadataKey = DefaultAccessTokenMetadataKey
+	}
+	if cfg.IDTokenMetadataKey == "" {
+		cfg.IDTokenMetadataKey = DefaultIdTokenMetadataKey
+	}
+	if cfg.StackIDMetadataKey == "" {
+		cfg.StackIDMetadataKey = DefaultStackIDMetadataKey
+	}
+	cfg.accessTokenAuthEnabled = true
+}
+
 func NewGrpcClientInterceptor(cfg *GrpcClientConfig, opts ...GrpcClientInterceptorOption) (*GrpcClientInterceptor, error) {
+	setGrpcClientCfgDefaults(cfg)
 	gci := &GrpcClientInterceptor{cfg: cfg}
-
-	if gci.cfg.AccessTokenMetadataKey == "" {
-		gci.cfg.AccessTokenMetadataKey = DefaultAccessTokenMetadataKey
-	}
-	if gci.cfg.IDTokenMetadataKey == "" {
-		gci.cfg.IDTokenMetadataKey = DefaultIdTokenMetadataKey
-	}
-	if gci.cfg.StackIDMetadataKey == "" {
-		gci.cfg.StackIDMetadataKey = DefaultStackIDMetadataKey
-	}
-
-	if gci.cfg.TokenRequest == nil && !gci.cfg.DisableAccessToken {
-		return nil, fmt.Errorf("missing required token request: %w", ErrMissingConfig)
-	}
 
 	for _, opt := range opts {
 		opt(gci)
 	}
 
-	if gci.tokenClient == nil && !gci.cfg.DisableAccessToken {
+	if gci.cfg.TokenRequest == nil && gci.cfg.accessTokenAuthEnabled {
+		return nil, fmt.Errorf("missing required token request: %w", ErrMissingConfig)
+	}
+
+	if gci.tokenClient == nil && gci.cfg.accessTokenAuthEnabled {
 		if gci.cfg.TokenClientConfig == nil {
 			return nil, fmt.Errorf("missing required token client config: %w", ErrMissingConfig)
 		}
@@ -140,7 +151,7 @@ func (gci *GrpcClientInterceptor) StreamClientInterceptor(ctx context.Context, d
 func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Context, error) {
 	md := metadata.Pairs()
 
-	if !gci.cfg.DisableAccessToken {
+	if gci.cfg.accessTokenAuthEnabled {
 		token, err := gci.tokenClient.Exchange(ctx, *gci.cfg.TokenRequest)
 		if err != nil {
 			return ctx, err

--- a/authn/grpc_client_interceptors_test.go
+++ b/authn/grpc_client_interceptors_test.go
@@ -64,7 +64,7 @@ func TestGrpcClientInterceptor_wrapContext(t *testing.T) {
 }
 
 func TestGrpcClientInterceptor_wrapContextNoAccessToken(t *testing.T) {
-	gci, err := NewGrpcClientInterceptor(&GrpcClientConfig{DisableAccessToken: true})
+	gci, err := NewGrpcClientInterceptor(&GrpcClientConfig{}, WithDisableAccessTokenOption())
 	require.NoError(t, err)
 
 	type idKey struct{}

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -111,6 +111,8 @@ func WithNamespaceFormatterLCOption(fmt authn.NamespaceFormatter) LegacyClientOp
 	}
 }
 
+// WithDisableAccessTokenLCOption is an option to disable access token authorization.
+// Warning: Using this option means there won't be any service authorization.
 func WithDisableAccessTokenLCOption() LegacyClientOption {
 	return func(c *LegacyClientImpl) {
 		c.authCfg.accessTokenAuthEnabled = false

--- a/authz/multitenant_client_test.go
+++ b/authz/multitenant_client_test.go
@@ -599,7 +599,7 @@ func TestLegacyClientImpl_Check_DisableAccessToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client, authz := setupLegacyClient()
-			client.authCfg.DisableAccessToken = true
+			WithDisableAccessTokenLCOption()(client)
 
 			authz.res = makeReadResponse(tt.res)
 
@@ -617,7 +617,7 @@ func TestLegacyClientImpl_Check_DisableAccessToken(t *testing.T) {
 func setupLegacyClient() (*LegacyClientImpl, *FakeAuthzServiceClient) {
 	fakeClient := &FakeAuthzServiceClient{}
 	return &LegacyClientImpl{
-		authCfg:      &MultiTenantClientConfig{},
+		authCfg:      &MultiTenantClientConfig{accessTokenAuthEnabled: true},
 		clientV1:     fakeClient,
 		cache:        cache.NewLocalCache(cache.Config{}),
 		namespaceFmt: authn.CloudNamespaceFormatter,


### PR DESCRIPTION
This PR is mainly clean ups.

- Inline `grpcAuthenticator`, `grpcClientInterceptor` & `legacyClient's` way to disable access tokens (using an option rather than a config field)
- Remove unnecessary returned error from `LegacyClientOption`.