### PR TITLE
PoC AuthN: Authenticator can validate token namespaces based on the request

### DIFF
--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 type testEnv struct {
-	authenticator *GrpcAuthenticator
+	authenticator *GrpcAuthenticatorImpl
 	atVerifier    *fakeAccessTokenVerifier
 	idVerifier    *fakeIDTokenVerifier
 }
@@ -23,7 +23,7 @@ func setupGrpcAuthenticator() *testEnv {
 		atVerifier: &fakeAccessTokenVerifier{},
 		idVerifier: &fakeIDTokenVerifier{},
 	}
-	env.authenticator = &GrpcAuthenticator{
+	env.authenticator = &GrpcAuthenticatorImpl{
 		cfg:          &GrpcAuthenticatorConfig{idTokenAuthEnabled: true, idTokenAuthRequired: true},
 		atVerifier:   env.atVerifier,
 		idVerifier:   env.idVerifier,


### PR DESCRIPTION
In this PR, I'm trying to see what it would take to do the namespace validation based on a stack ID that could be taken from the request, the metadata or the tokens.
It looks complicated to handle the gRPC stream scenario with that approach. 

![image](https://github.com/user-attachments/assets/a1ad98de-7049-42ea-8ddb-f66c198e2522)


An alternative would be not to do any namespace validation in this middleware and let the handler code or another middleware do it.

This is what I'm assessing in #61 