### PR TITLE
AuthNZ: Extract namespace validation from gRPC authentication 

### DIFF
--- a/authn/caller_info.go
+++ b/authn/caller_info.go
@@ -5,7 +5,6 @@ import "context"
 type CallerAuthInfo struct {
 	IDTokenClaims     *Claims[IDTokenClaims]
 	AccessTokenClaims Claims[AccessTokenClaims]
-	StackID           int64
 }
 
 type CallerAuthInfoContextKey struct{}

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -14,12 +14,11 @@ var (
 	ErrorMissingMetadata    = status.Error(codes.Unauthenticated, "unauthenticated: no metadata found")
 	ErrorMissingIDToken     = status.Error(codes.Unauthenticated, "unauthenticated: missing id token")
 	ErrorMissingAccessToken = status.Error(codes.Unauthenticated, "unauthenticated: missing access token")
-	ErrorInvalidStackID     = status.Error(codes.PermissionDenied, "unauthorized: invalid stack ID")
 	ErrorInvalidIDToken     = status.Error(codes.PermissionDenied, "unauthorized: invalid id token")
 	ErrorInvalidAccessToken = status.Error(codes.PermissionDenied, "unauthorized: invalid access token")
 )
 
-// TODO (gamab) - StackID extract should be configurable - could come from the metadata, path, id token.
+// TODO (gamab) - Validate service and user namespace match
 
 // GrpcAuthenticatorOptions
 type GrpcAuthenticatorOption func(*GrpcAuthenticator)

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -18,7 +18,7 @@ var (
 	ErrorInvalidAccessToken = status.Error(codes.PermissionDenied, "unauthorized: invalid access token")
 )
 
-// TODO (gamab) - Validate service and user namespace match
+// TODO (gamab) - Validate service and user namespace match ?
 
 // GrpcAuthenticatorOptions
 type GrpcAuthenticatorOption func(*GrpcAuthenticator)

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -182,6 +182,21 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 				AccessTokenClaims: Claims[AccessTokenClaims]{},
 			},
 		},
+		{
+			name: "access and id token namespaces mismatch",
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token", DefaultIdTokenMetadataKey, "id-token"),
+			initEnv: func(env *testEnv) {
+				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
+					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
+					Rest:   AccessTokenClaims{Namespace: "stack-13"},
+				}
+				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
+					Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
+					Rest:   IDTokenClaims{Namespace: "stack-12"},
+				}
+			},
+			wantErr: ErrorNamespacesMismatch,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -24,10 +24,9 @@ func setupGrpcAuthenticator() *testEnv {
 		idVerifier: &fakeIDTokenVerifier{},
 	}
 	env.authenticator = &GrpcAuthenticator{
-		cfg:          &GrpcAuthenticatorConfig{idTokenAuthEnabled: true, idTokenAuthRequired: true},
-		atVerifier:   env.atVerifier,
-		idVerifier:   env.idVerifier,
-		namespaceFmt: CloudNamespaceFormatter,
+		cfg:        &GrpcAuthenticatorConfig{idTokenAuthEnabled: true, idTokenAuthRequired: true},
+		atVerifier: env.atVerifier,
+		idVerifier: env.idVerifier,
 	}
 	setGrpcAuthenticatorCfgDefaults(env.authenticator.cfg)
 
@@ -51,7 +50,6 @@ func TestGrpcAuthenticator_NewGrpcAuthenticator(t *testing.T) {
 		// Config has default metadata keys
 		require.Equal(t, DefaultAccessTokenMetadataKey, ga.cfg.AccessTokenMetadataKey)
 		require.Equal(t, DefaultIdTokenMetadataKey, ga.cfg.IDTokenMetadataKey)
-		require.Equal(t, DefaultStackIDMetadataKey, ga.cfg.StackIDMetadataKey)
 		// ID token authentication is disabled by default
 		require.Nil(t, ga.idVerifier)
 	})
@@ -97,23 +95,13 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 			wantErr: ErrorMissingMetadata,
 		},
 		{
-			name:    "missing stack ID",
-			md:      metadata.Pairs(),
-			wantErr: ErrorMissingMetadata,
-		},
-		{
-			name:    "invalid stack ID",
-			md:      metadata.Pairs(DefaultStackIDMetadataKey, "invalid-stack-id"),
-			wantErr: ErrorInvalidStackID,
-		},
-		{
 			name:    "missing access token",
-			md:      metadata.Pairs(DefaultStackIDMetadataKey, "12"),
+			md:      metadata.Pairs(),
 			wantErr: ErrorMissingAccessToken,
 		},
 		{
 			name: "missing id token",
-			md:   metadata.Pairs(DefaultStackIDMetadataKey, "12", DefaultAccessTokenMetadataKey, "access-token"),
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
 			initEnv: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
@@ -124,7 +112,7 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 		},
 		{
 			name: "valid authentication",
-			md:   metadata.Pairs(DefaultStackIDMetadataKey, "12", DefaultAccessTokenMetadataKey, "access-token", DefaultIdTokenMetadataKey, "id-token"),
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token", DefaultIdTokenMetadataKey, "id-token"),
 			initEnv: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
@@ -136,7 +124,6 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 				}
 			},
 			want: CallerAuthInfo{
-				StackID: 12,
 				AccessTokenClaims: Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
 					Rest:   AccessTokenClaims{Namespace: "*"},
@@ -149,7 +136,7 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 		},
 		{
 			name: "valid service authentication no id token",
-			md:   metadata.Pairs(DefaultStackIDMetadataKey, "12", DefaultAccessTokenMetadataKey, "access-token"),
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
 			initEnv: func(env *testEnv) {
 				env.authenticator.cfg.idTokenAuthEnabled = true
 				env.authenticator.cfg.idTokenAuthRequired = false
@@ -159,7 +146,6 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 				}
 			},
 			want: CallerAuthInfo{
-				StackID: 12,
 				AccessTokenClaims: Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
 					Rest:   AccessTokenClaims{Namespace: "*"},
@@ -168,7 +154,7 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 		},
 		{
 			name: "valid service authentication disable id token verification",
-			md:   metadata.Pairs(DefaultStackIDMetadataKey, "12", DefaultAccessTokenMetadataKey, "access-token", DefaultIdTokenMetadataKey, "id-token"),
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token", DefaultIdTokenMetadataKey, "id-token"),
 			initEnv: func(env *testEnv) {
 				env.authenticator.cfg.idTokenAuthEnabled = false
 				env.authenticator.cfg.idTokenAuthRequired = false
@@ -178,7 +164,6 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 				}
 			},
 			want: CallerAuthInfo{
-				StackID: 12,
 				AccessTokenClaims: Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
 					Rest:   AccessTokenClaims{Namespace: "*"},
@@ -187,14 +172,13 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 		},
 		{
 			name: "valid no authentication when both access and id token are disabled",
-			md:   metadata.Pairs(DefaultStackIDMetadataKey, "12", DefaultAccessTokenMetadataKey, "access-token", DefaultIdTokenMetadataKey, "id-token"),
+			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token", DefaultIdTokenMetadataKey, "id-token"),
 			initEnv: func(env *testEnv) {
 				env.authenticator.cfg.accessTokenAuthEnabled = false
 				env.authenticator.cfg.idTokenAuthEnabled = false
 				env.authenticator.cfg.idTokenAuthRequired = false
 			},
 			want: CallerAuthInfo{
-				StackID:           12,
 				AccessTokenClaims: Claims[AccessTokenClaims]{},
 			},
 		},
@@ -223,7 +207,6 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, got)
-			require.Equal(t, tt.want.StackID, got.StackID)
 			if tt.want.AccessTokenClaims.Claims == nil {
 				require.Nil(t, got.AccessTokenClaims.Claims)
 			} else {
@@ -257,16 +240,6 @@ func TestGrpcAuthenticator_authenticateService(t *testing.T) {
 		{
 			name:    "invalid access token",
 			md:      metadata.Pairs(DefaultAccessTokenMetadataKey, "invalid-access-token"),
-			wantErr: ErrorInvalidAccessToken,
-		},
-		{
-			name: "invalid namespace",
-			md:   metadata.Pairs(DefaultAccessTokenMetadataKey, "access-token"),
-			initEnv: func(env *testEnv) {
-				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
-					Rest: AccessTokenClaims{Namespace: "stack-13"},
-				}
-			},
 			wantErr: ErrorInvalidAccessToken,
 		},
 		{
@@ -327,7 +300,7 @@ func TestGrpcAuthenticator_authenticateService(t *testing.T) {
 				tt.initEnv(env)
 			}
 
-			got, err := env.authenticator.authenticateService(context.Background(), 12, tt.md)
+			got, err := env.authenticator.authenticateService(context.Background(), tt.md)
 			if tt.wantErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.wantErr)
@@ -357,16 +330,6 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 		{
 			name:    "invalid id token",
 			md:      metadata.Pairs(DefaultIdTokenMetadataKey, "invalid-id-token"),
-			wantErr: ErrorInvalidIDToken,
-		},
-		{
-			name: "invalid namespace",
-			md:   metadata.Pairs(DefaultIdTokenMetadataKey, "id-token"),
-			initEnv: func(env *testEnv) {
-				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
-					Rest: IDTokenClaims{Namespace: "stack-13"},
-				}
-			},
 			wantErr: ErrorInvalidIDToken,
 		},
 		{
@@ -413,7 +376,7 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 				tt.initEnv(env)
 			}
 
-			got, err := env.authenticator.authenticateUser(context.Background(), 12, tt.md)
+			got, err := env.authenticator.authenticateUser(context.Background(), tt.md)
 			if tt.wantErr != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.wantErr)

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -11,7 +11,6 @@ import (
 const (
 	DefaultAccessTokenMetadataKey = "X-Access-Token"
 	DefaultIdTokenMetadataKey     = "X-Id-Token"
-	DefaultStackIDMetadataKey     = "X-Stack-Id"
 )
 
 // GrpcClientConfig holds the configuration for the gRPC client interceptor.
@@ -22,9 +21,6 @@ type GrpcClientConfig struct {
 	// IDTokenMetadataKey is the key used to store the ID token in the outgoing context metadata.
 	// Not required if IDTokenExtractor is provided. Defaults to "X-Id-Token".
 	IDTokenMetadataKey string
-	// StackIDMetadataKey is the key used to store the stack ID in the outgoing context metadata.
-	// Defaults to "X-Stack-Id".
-	StackIDMetadataKey string
 	// TokenClientConfig holds the configuration for the token exchange client.
 	// Not required if TokenClient is provided.
 	TokenClientConfig *TokenExchangeConfig
@@ -66,18 +62,6 @@ func WithIDTokenExtractorOption(extractor func(context.Context) (string, error))
 	}
 }
 
-func WithStackIDExtractorOption(extractor func(context.Context) (int64, error)) GrpcClientInterceptorOption {
-	return func(gci *GrpcClientInterceptor) {
-		WithMetadataExtractorOption(func(ctx context.Context) (key string, values []string, err error) {
-			stackID, err := extractor(ctx)
-			if err != nil {
-				return "", nil, err
-			}
-			return gci.cfg.StackIDMetadataKey, []string{fmt.Sprintf("%d", stackID)}, nil
-		})(gci)
-	}
-}
-
 func WithMetadataExtractorOption(extractors ...ContextMetadataExtractor) GrpcClientInterceptorOption {
 	return func(gci *GrpcClientInterceptor) {
 		gci.metadataExtractors = append(gci.metadataExtractors, extractors...)
@@ -98,9 +82,6 @@ func setGrpcClientCfgDefaults(cfg *GrpcClientConfig) {
 	}
 	if cfg.IDTokenMetadataKey == "" {
 		cfg.IDTokenMetadataKey = DefaultIdTokenMetadataKey
-	}
-	if cfg.StackIDMetadataKey == "" {
-		cfg.StackIDMetadataKey = DefaultStackIDMetadataKey
 	}
 	cfg.accessTokenAuthEnabled = true
 }

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -1,0 +1,73 @@
+package authz
+
+import (
+	"github.com/grafana/authlib/authn"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	ErrorMissingIDToken               = status.Errorf(codes.Unauthenticated, "unauthenticated: missing id token")
+	ErrorIDTokenNamespaceMismatch     = status.Errorf(codes.PermissionDenied, "unauthorized: id token namespace does not match expected namespace")
+	ErrorAccessTokenNamespaceMismatch = status.Errorf(codes.PermissionDenied, "unauthorized: access token namespace does not match expected namespace")
+)
+
+type NamespaceAuthorizer interface {
+	Validate(caller authn.CallerAuthInfo, stackID int64) error
+}
+
+type NamespaceAuthorizerOption func(*NamespaceAuthorizerImpl)
+
+type NamespaceAuthorizerImpl struct {
+	namespaceFmt authn.NamespaceFormatter
+
+	idTokenEnabled     bool
+	idTokenRequired    bool
+	accessTokenEnabled bool
+}
+
+func WithIDTokenNamespaceAuthorizerOption(required bool) NamespaceAuthorizerOption {
+	return func(na *NamespaceAuthorizerImpl) {
+		na.idTokenEnabled = true
+		na.idTokenRequired = required
+	}
+}
+
+func WithDisableAccessTokenNamespaceAuthorizerOption() NamespaceAuthorizerOption {
+	return func(na *NamespaceAuthorizerImpl) {
+		na.accessTokenEnabled = false
+	}
+}
+
+func NewNamespaceAuthorizer(namespaceFmt authn.NamespaceFormatter, opts ...NamespaceAuthorizerOption) *NamespaceAuthorizerImpl {
+	na := &NamespaceAuthorizerImpl{
+		namespaceFmt:       namespaceFmt,
+		idTokenEnabled:     false,
+		idTokenRequired:    false,
+		accessTokenEnabled: true,
+	}
+
+	for _, opt := range opts {
+		opt(na)
+	}
+
+	return na
+}
+
+func (na *NamespaceAuthorizerImpl) Validate(caller authn.CallerAuthInfo, stackID int64) error {
+	expectedNamespace := na.namespaceFmt(stackID)
+
+	if na.idTokenEnabled {
+		if caller.IDTokenClaims == nil {
+			if na.idTokenRequired {
+				return ErrorMissingIDToken
+			}
+		} else if caller.IDTokenClaims.Rest.Namespace != expectedNamespace {
+			return ErrorIDTokenNamespaceMismatch
+		}
+	}
+	if na.accessTokenEnabled && !caller.AccessTokenClaims.Rest.NamespaceMatches(expectedNamespace) {
+		return ErrorAccessTokenNamespaceMismatch
+	}
+	return nil
+}

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -1,9 +1,10 @@
 package authz
 
 import (
-	"github.com/grafana/authlib/authn"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grafana/authlib/authn"
 )
 
 var (

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -3,8 +3,9 @@ package authz
 import (
 	"testing"
 
-	"github.com/grafana/authlib/authn"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/authlib/authn"
 )
 
 func TestNamespaceAuthorizerImpl_ValidateAccessTokenOnly(t *testing.T) {

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/grafana/authlib/authn"
 )
 
-func TestNamespaceAuthorizerImpl_ValidateAccessTokenOnly(t *testing.T) {
+func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	stackID := int64(12)
 	tests := []struct {
 		name    string
@@ -47,13 +47,13 @@ func TestNamespaceAuthorizerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na := NewNamespaceAuthorizer(tt.nsFmt)
-			require.ErrorIs(t, na.Validate(tt.caller, stackID), tt.wantErr)
+			na := NewNamespaceAccessChecker(tt.nsFmt)
+			require.ErrorIs(t, na.CheckAccess(tt.caller, stackID), tt.wantErr)
 		})
 	}
 }
 
-func TestNamespaceAuthorizerImpl_ValidateIDTokenOnly(t *testing.T) {
+func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 	stackID := int64(12)
 	tests := []struct {
 		name    string
@@ -85,13 +85,13 @@ func TestNamespaceAuthorizerImpl_ValidateIDTokenOnly(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na := NewNamespaceAuthorizer(tt.nsFmt, WithIDTokenNamespaceAuthorizerOption(true), WithDisableAccessTokenNamespaceAuthorizerOption())
-			require.ErrorIs(t, na.Validate(tt.caller, stackID), tt.wantErr)
+			na := NewNamespaceAccessChecker(tt.nsFmt, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
+			require.ErrorIs(t, na.CheckAccess(tt.caller, stackID), tt.wantErr)
 		})
 	}
 }
 
-func TestNamespaceAuthorizerImpl_ValidateBoth(t *testing.T) {
+func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 	stackID := int64(12)
 	tests := []struct {
 		name    string
@@ -143,8 +143,8 @@ func TestNamespaceAuthorizerImpl_ValidateBoth(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na := NewNamespaceAuthorizer(tt.nsFmt, WithIDTokenNamespaceAuthorizerOption(false))
-			require.ErrorIs(t, na.Validate(tt.caller, stackID), tt.wantErr)
+			na := NewNamespaceAccessChecker(tt.nsFmt, WithIDTokenNamespaceAccessCheckerOption(false))
+			require.ErrorIs(t, na.CheckAccess(tt.caller, stackID), tt.wantErr)
 		})
 	}
 }

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -1,0 +1,149 @@
+package authz
+
+import (
+	"testing"
+
+	"github.com/grafana/authlib/authn"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespaceAuthorizerImpl_ValidateAccessTokenOnly(t *testing.T) {
+	stackID := int64(12)
+	tests := []struct {
+		name    string
+		nsFmt   authn.NamespaceFormatter
+		caller  authn.CallerAuthInfo
+		wantErr error
+	}{
+		{
+			name:    "missing access token",
+			nsFmt:   authn.CloudNamespaceFormatter,
+			caller:  authn.CallerAuthInfo{},
+			wantErr: ErrorAccessTokenNamespaceMismatch,
+		},
+		{
+			name:  "access token match",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}},
+			},
+		},
+		{
+			name:  "access token wildcard match",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}},
+			},
+		},
+		{
+			name:  "access token mismatch",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-13"}},
+			},
+			wantErr: ErrorAccessTokenNamespaceMismatch,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			na := NewNamespaceAuthorizer(tt.nsFmt)
+			require.ErrorIs(t, na.Validate(tt.caller, stackID), tt.wantErr)
+		})
+	}
+}
+
+func TestNamespaceAuthorizerImpl_ValidateIDTokenOnly(t *testing.T) {
+	stackID := int64(12)
+	tests := []struct {
+		name    string
+		nsFmt   authn.NamespaceFormatter
+		caller  authn.CallerAuthInfo
+		wantErr error
+	}{
+		{
+			name:    "missing id token",
+			nsFmt:   authn.CloudNamespaceFormatter,
+			caller:  authn.CallerAuthInfo{},
+			wantErr: ErrorMissingIDToken,
+		},
+		{
+			name:  "id token match",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}},
+			},
+		},
+		{
+			name:  "id token mismatch",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-13"}},
+			},
+			wantErr: ErrorIDTokenNamespaceMismatch,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			na := NewNamespaceAuthorizer(tt.nsFmt, WithIDTokenNamespaceAuthorizerOption(true), WithDisableAccessTokenNamespaceAuthorizerOption())
+			require.ErrorIs(t, na.Validate(tt.caller, stackID), tt.wantErr)
+		})
+	}
+}
+
+func TestNamespaceAuthorizerImpl_ValidateBoth(t *testing.T) {
+	stackID := int64(12)
+	tests := []struct {
+		name    string
+		nsFmt   authn.NamespaceFormatter
+		caller  authn.CallerAuthInfo
+		wantErr error
+	}{
+		{
+			name:  "id token and access token match",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				IDTokenClaims:     &authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}},
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}},
+			},
+		},
+		{
+			name:  "id token and access token wildcard match",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				IDTokenClaims:     &authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}},
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}},
+			},
+		},
+		{
+			name:  "access token mismatch",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				IDTokenClaims:     &authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}},
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-13"}},
+			},
+			wantErr: ErrorAccessTokenNamespaceMismatch,
+		},
+		{
+			name:  "id token mismatch",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				IDTokenClaims:     &authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-13"}},
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}},
+			},
+			wantErr: ErrorIDTokenNamespaceMismatch,
+		},
+		{
+			name:  "id token missing but not required",
+			nsFmt: authn.CloudNamespaceFormatter,
+			caller: authn.CallerAuthInfo{
+				AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			na := NewNamespaceAuthorizer(tt.nsFmt, WithIDTokenNamespaceAuthorizerOption(false))
+			require.ErrorIs(t, na.Validate(tt.caller, stackID), tt.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
**Aka: three step authnz (authentication, namespace access control, permission access control)**

In #60 I tried to assess if I could extract the stackID required for the namespace check from different sources. It turns out it's complicated in the gRPC Stream case.
It made me question whether performing namespace validation in the authentication interceptor was the correct thing after all.

- Authentication: Verifying the identity of the caller. In our case, this is handled by validating the JWT tokens against the signing authority. We've already confirmed **who** is making the request.
- Authorization: Determining if the authenticated caller has the necessary permissions to access a specific resource or perform a specific action. This is where the **namespace validation** and **rbac permission checks** comes into play.

With this PR I'm extracting namespace validation from the gRPC authentication code. The namespace validation code can now be placed in its own interceptor or called at handler level; in the case where the stackID is part of the message which is the case for the authz-service, that makes sense.