### PR TITLE
Adjust ID Token claims

### DIFF
--- a/authn/claims.go
+++ b/authn/claims.go
@@ -160,11 +160,6 @@ func (c *Identity) UID() string {
 }
 
 // UID implements claims.IdentityClaims.
-func (c *Identity) InternalID() int64 {
-	return c.claims.Rest.InternalID
-}
-
-// UID implements claims.IdentityClaims.
 func (c *Identity) OrgID() int64 {
 	return c.claims.Rest.OrgID
 }

--- a/authn/claims.go
+++ b/authn/claims.go
@@ -1,7 +1,6 @@
 package authn
 
 import (
-	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -155,9 +154,9 @@ func (c *Identity) Subject() string {
 	return c.claims.Subject
 }
 
-// UID implements claims.IdentityClaims.
-func (c *Identity) UID() string {
-	return strings.TrimPrefix(c.claims.Rest.UID, c.IdentityType().AsPrefix())
+// Identifier implements claims.IdentityClaims.
+func (c *Identity) Identifier() string {
+	return c.claims.Rest.Identifier
 }
 
 // UID implements claims.IdentityClaims.

--- a/authn/claims.go
+++ b/authn/claims.go
@@ -160,11 +160,6 @@ func (c *Identity) UID() string {
 }
 
 // UID implements claims.IdentityClaims.
-func (c *Identity) OrgID() int64 {
-	return c.claims.Rest.OrgID
-}
-
-// UID implements claims.IdentityClaims.
 func (c *Identity) IdentityType() claims.IdentityType {
 	return c.claims.Rest.Type
 }

--- a/authn/claims.go
+++ b/authn/claims.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
@@ -156,7 +157,7 @@ func (c *Identity) Subject() string {
 
 // UID implements claims.IdentityClaims.
 func (c *Identity) UID() string {
-	return c.claims.Rest.UID
+	return strings.TrimPrefix(c.claims.Rest.UID, c.IdentityType().AsPrefix())
 }
 
 // UID implements claims.IdentityClaims.

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -22,7 +22,7 @@ type IDTokenClaims struct {
 	// Username of the user (login attribute on the Identity)
 	Username string `json:"username,omitempty"`
 	// Display name of the user (name attribute if it is set, otherwise the login or email)
-	DisplayName string `json:"name"`
+	DisplayName string `json:"name,omitempty"`
 }
 
 // Helper for the id

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -8,7 +8,7 @@ import (
 )
 
 type IDTokenClaims struct {
-	// UID is the unique ID of the user (UID attribute)
+	// UID is the unique ID of the of entity, it is a typed id e.g. `user:some-uid`.
 	UID string `json:"uid"`
 	// The type of user
 	Type claims.IdentityType `json:"type"`
@@ -40,7 +40,7 @@ func (c IDTokenClaims) getK8sName() string {
 	if c.Email != "" {
 		return c.Email
 	}
-	return c.asTypedUID()
+	return c.UID
 }
 
 func (c IDTokenClaims) NamespaceMatches(namespace string) bool {

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -20,7 +20,7 @@ type IDTokenClaims struct {
 	Email           string `json:"email,omitempty"`
 	EmailVerified   bool   `json:"email_verified,omitempty"`
 	// Username of the user (login attribute on the Identity)
-	Username string `json:"username"`
+	Username string `json:"username,omitempty"`
 	// Display name of the user (name attribute if it is set, otherwise the login or email)
 	DisplayName string `json:"name"`
 }

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -12,9 +12,6 @@ type IDTokenClaims struct {
 	UID string `json:"uid"`
 	// The type of user
 	Type claims.IdentityType `json:"type"`
-	// The internal numeric ID
-	// Deprecated: use UID if possible
-	InternalID int64 `json:"id,omitempty"`
 	// The internal numeric org ID
 	// Deprecated: use namespace where possible
 	OrgID int64 `json:"orgId,omitempty"`

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -8,7 +8,7 @@ import (
 )
 
 type IDTokenClaims struct {
-	// Identifier is the unique ID of the of entity, it is a typed id e.g. `user:some-uid`.
+	// Identifier is the unique ID of the of entity
 	Identifier string `json:"identifier"`
 	// The type of the entity.
 	Type claims.IdentityType `json:"type"`

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -12,9 +12,6 @@ type IDTokenClaims struct {
 	UID string `json:"uid"`
 	// The type of user
 	Type claims.IdentityType `json:"type"`
-	// The internal numeric org ID
-	// Deprecated: use namespace where possible
-	OrgID int64 `json:"orgId,omitempty"`
 	// Namespace takes the form of '<type>-<id>', '*' means all namespaces.
 	// Type can be either org or stack.
 	Namespace string `json:"namespace"`

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -8,9 +8,9 @@ import (
 )
 
 type IDTokenClaims struct {
-	// UID is the unique ID of the of entity, it is a typed id e.g. `user:some-uid`.
-	UID string `json:"uid"`
-	// The type of user
+	// Identifier is the unique ID of the of entity, it is a typed id e.g. `user:some-uid`.
+	Identifier string `json:"identifier"`
+	// The type of the entity.
 	Type claims.IdentityType `json:"type"`
 	// Namespace takes the form of '<type>-<id>', '*' means all namespaces.
 	// Type can be either org or stack.
@@ -21,13 +21,13 @@ type IDTokenClaims struct {
 	EmailVerified   bool   `json:"email_verified"`
 	// Username of the user (login attribute on the Identity)
 	Username string `json:"username"`
-	// Display Name of the user (name attribute if it is set, otherwise the login or email)
+	// Display name of the user (name attribute if it is set, otherwise the login or email)
 	DisplayName string `json:"name"`
 }
 
 // Helper for the id
 func (c IDTokenClaims) asTypedUID() string {
-	return fmt.Sprintf("%s:%s", c.Type, c.UID)
+	return fmt.Sprintf("%s:%s", c.Type, c.Identifier)
 }
 
 func (c IDTokenClaims) getK8sName() string {
@@ -40,7 +40,7 @@ func (c IDTokenClaims) getK8sName() string {
 	if c.Email != "" {
 		return c.Email
 	}
-	return c.UID
+	return c.Identifier
 }
 
 func (c IDTokenClaims) NamespaceMatches(namespace string) bool {

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -18,7 +18,7 @@ type IDTokenClaims struct {
 	// AuthenticatedBy is the method used to authenticate the identity.
 	AuthenticatedBy string `json:"authenticatedBy"`
 	Email           string `json:"email"`
-	EmailVerified   bool   `json:"email_verified"`
+	EmailVerified   bool   `json:"email_verified,omitempty"`
 	// Username of the user (login attribute on the Identity)
 	Username string `json:"username"`
 	// Display name of the user (name attribute if it is set, otherwise the login or email)

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -16,8 +16,8 @@ type IDTokenClaims struct {
 	// Type can be either org or stack.
 	Namespace string `json:"namespace"`
 	// AuthenticatedBy is the method used to authenticate the identity.
-	AuthenticatedBy string `json:"authenticatedBy"`
-	Email           string `json:"email"`
+	AuthenticatedBy string `json:"authenticatedBy,omitempty"`
+	Email           string `json:"email,omitempty"`
 	EmailVerified   bool   `json:"email_verified,omitempty"`
 	// Username of the user (login attribute on the Identity)
 	Username string `json:"username"`

--- a/claims/token.go
+++ b/claims/token.go
@@ -14,7 +14,7 @@ type AuthInfo interface {
 	// GetUID returns a unique value for a particular user that will change
 	// if the user is removed from the system and another user is added with
 	// the same name.
-	// This be in the form: <IdentityType>:<Identifier>
+	// This will be in the form: <IdentityType>:<Identifier>
 	GetUID() string
 
 	// GetGroups returns the names of the groups the user is a member of

--- a/claims/token.go
+++ b/claims/token.go
@@ -122,10 +122,6 @@ type IdentityClaims interface {
 	// UID is a unique identifier for this identity.
 	UID() string
 
-	// The numeric internal ID for this identity.
-	// Deprecated: Use UID when possible
-	InternalID() int64
-
 	// The internal org-id
 	// Deprecated: Use namespace when possible
 	OrgID() int64

--- a/claims/token.go
+++ b/claims/token.go
@@ -14,7 +14,7 @@ type AuthInfo interface {
 	// GetUID returns a unique value for a particular user that will change
 	// if the user is removed from the system and another user is added with
 	// the same name.
-	// This will either be a full GUID, or in the form: <IdentityType>:<Identity.UID>
+	// This be in the form: <IdentityType>:<Identifier>
 	GetUID() string
 
 	// GetGroups returns the names of the groups the user is a member of
@@ -119,8 +119,9 @@ type IdentityClaims interface {
 	// Type indicates what kind of identity this is
 	IdentityType() IdentityType
 
-	// UID is a unique identifier for this identity.
-	UID() string
+	// Identifier is a unique identifier for this IdentityType within a namespace.
+	// For some identity types this can be empty e.g. Anonymous.
+	Identifier() string
 
 	// Namespace takes the form of '<type>-<id>', '*' means all namespaces.
 	// In grafana the can be either org or stack.
@@ -128,7 +129,7 @@ type IdentityClaims interface {
 	Namespace() string
 
 	// AuthenticatedBy is the method used to authenticate the identity.
-	// Examples: oauth, oauth_azuread, etc
+	// Examples: password, oauth_azuread, etc
 	AuthenticatedBy() string
 
 	// The identity email

--- a/claims/token.go
+++ b/claims/token.go
@@ -122,10 +122,6 @@ type IdentityClaims interface {
 	// UID is a unique identifier for this identity.
 	UID() string
 
-	// The internal org-id
-	// Deprecated: Use namespace when possible
-	OrgID() int64
-
 	// Namespace takes the form of '<type>-<id>', '*' means all namespaces.
 	// In grafana the can be either org or stack.
 	// The claims are valid within this namespace

--- a/claims/type.go
+++ b/claims/type.go
@@ -27,10 +27,6 @@ func (n IdentityType) String() string {
 	return string(n)
 }
 
-func (n IdentityType) AsPrefix() string {
-	return string(n) + ":"
-}
-
 func ParseType(str string) (IdentityType, error) {
 	switch str {
 	case string(TypeUser):

--- a/claims/type.go
+++ b/claims/type.go
@@ -27,6 +27,10 @@ func (n IdentityType) String() string {
 	return string(n)
 }
 
+func (n IdentityType) AsPrefix() string {
+	return string(n) + ":"
+}
+
 func ParseType(str string) (IdentityType, error) {
 	switch str {
 	case string(TypeUser):


### PR DESCRIPTION
After inspecting what we get in our claims we need to adjust the methods a bit, specifically UID is sent with a prefix.
I will also make a pr in grafana to add the identity type to all issued tokens.

We also probably won't need InternalID and OrgID for now so lets remove them

Edit:
After talk with Ryan we have adjusted the interface and id claims a bit. Nothing should be relying on these types yet so we should be fine to break them