### PR TITLE
Switching from `authn.CallerAuthInfo` to `claims.AuthInfo`

### DIFF
--- a/authn/claims.go
+++ b/authn/claims.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
+
 	"github.com/grafana/authlib/claims"
 )
 
@@ -60,11 +61,11 @@ type Access struct {
 	claims Claims[AccessTokenClaims]
 }
 
-func NewAccessClaims(c Claims[AccessTokenClaims]) claims.AccessClaims {
+func NewAccessClaims(c Claims[AccessTokenClaims]) *Access {
 	return &Access{claims: c}
 }
 
-func NewIdentityClaims(c Claims[IDTokenClaims]) claims.IdentityClaims {
+func NewIdentityClaims(c Claims[IDTokenClaims]) *Identity {
 	return &Identity{claims: c}
 }
 
@@ -174,6 +175,10 @@ func (c *Access) Audience() []string {
 	return c.claims.Audience
 }
 
+func (c *Identity) IsNil() bool {
+	return c == nil
+}
+
 // Expiry implements claims.IdentityClaims.
 func (c *Access) Expiry() *time.Time {
 	if c.claims.Expiry == nil {
@@ -234,6 +239,10 @@ func (c *Access) Permissions() []string {
 // Scopes implements claims.AccessClaims.
 func (c *Access) Scopes() []string {
 	return c.claims.Rest.Scopes
+}
+
+func (c *Access) IsNil() bool {
+	return c == nil
 }
 
 // Audience implements claims.IdentityClaims.

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+
+	"github.com/grafana/authlib/claims"
 )
 
 var (
@@ -119,7 +121,7 @@ func NewGrpcAuthenticator(cfg *GrpcAuthenticatorConfig, opts ...GrpcAuthenticato
 
 // Authenticate authenticates the incoming request based on the access token and ID token, and returns the context with the caller information.
 func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context, error) {
-	callerInfo := CallerAuthInfo{}
+	authInfo := AuthInfo{}
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -131,7 +133,9 @@ func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context,
 		if err != nil {
 			return nil, err
 		}
-		callerInfo.AccessTokenClaims = *atClaims
+		if atClaims != nil {
+			authInfo.AccessClaims = &Access{claims: *atClaims}
+		}
 	}
 
 	if ga.cfg.idTokenAuthEnabled {
@@ -139,17 +143,27 @@ func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context,
 		if err != nil {
 			return nil, err
 		}
-		callerInfo.IDTokenClaims = idClaims
-	}
-
-	// Validate accessToken namespace matches IDToken namespace
-	if ga.cfg.accessTokenAuthEnabled && ga.cfg.idTokenAuthEnabled && callerInfo.IDTokenClaims != nil {
-		if !callerInfo.AccessTokenClaims.Rest.NamespaceMatches(callerInfo.IDTokenClaims.Rest.Namespace) {
-			return nil, ErrorNamespacesMismatch
+		if idClaims != nil {
+			authInfo.IdentityClaims = NewIdentityClaims(*idClaims)
 		}
 	}
 
-	return AddCallerAuthInfoToContext(ctx, callerInfo), nil
+	// Validate accessToken namespace matches IDToken namespace
+	if ga.cfg.accessTokenAuthEnabled && ga.cfg.idTokenAuthEnabled {
+		accessToken := authInfo.GetAccess()
+		identityToken := authInfo.GetIdentity()
+
+		if accessToken != nil && !accessToken.IsNil() && identityToken != nil && !identityToken.IsNil() {
+			accessNamespace := accessToken.Namespace()
+			identityNamespace := identityToken.Namespace()
+
+			if accessNamespace != "*" && accessNamespace != identityNamespace {
+				return nil, ErrorNamespacesMismatch
+			}
+		}
+	}
+
+	return claims.WithClaims(ctx, &authInfo), nil
 }
 
 func (ga *GrpcAuthenticator) authenticateService(ctx context.Context, md metadata.MD) (*Claims[AccessTokenClaims], error) {

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -15,7 +15,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/grafana/authlib/authn"
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	"github.com/grafana/authlib/cache"
 	"github.com/grafana/authlib/claims"
@@ -31,8 +30,7 @@ var (
 )
 
 type CheckRequest struct {
-	// nolint:staticcheck
-	Caller     authn.CallerAuthInfo
+	Caller     claims.AuthInfo
 	StackID    int64
 	Action     string
 	Resource   *Resource
@@ -186,10 +184,12 @@ func (r *CheckRequest) Validate(accessTokenEnabled bool) error {
 	if r.Action == "" {
 		return ErrMissingAction
 	}
-	if accessTokenEnabled && r.Caller.AccessTokenClaims.Claims == nil {
+	accessClaims := r.Caller.GetAccess()
+	if accessTokenEnabled && (accessClaims == nil || accessClaims.IsNil()) {
 		return ErrMissingCaller
 	}
-	if r.Caller.IDTokenClaims != nil && r.Caller.IDTokenClaims.Subject == "" {
+	idClaims := r.Caller.GetIdentity()
+	if idClaims != nil && !idClaims.IsNil() && r.Caller.GetIdentity().Subject() == "" {
 		return ErrMissingSubject
 	}
 	return nil
@@ -208,8 +208,8 @@ func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, 
 		return false, nil
 	}
 
-	if c.authCfg.accessTokenAuthEnabled {
-		span.SetAttributes(attribute.String("service", req.Caller.AccessTokenClaims.Subject))
+	if c.authCfg.accessTokenAuthEnabled && req.Caller.GetAccess() != nil {
+		span.SetAttributes(attribute.String("service", req.Caller.GetAccess().Subject()))
 	}
 	span.SetAttributes(attribute.Int64("stack_id", req.StackID))
 	span.SetAttributes(attribute.String("action", req.Action))
@@ -217,16 +217,20 @@ func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, 
 		span.SetAttributes(attribute.String("resource", req.Resource.Scope()))
 		span.SetAttributes(attribute.Int("contextual", len(req.Contextual)))
 	}
-	span.SetAttributes(attribute.Bool("with_user", req.Caller.IDTokenClaims != nil))
+	span.SetAttributes(attribute.Bool("with_user", req.Caller.GetIdentity() != nil))
 
 	// No user => check on the service permissions
-	if req.Caller.IDTokenClaims == nil {
+	if req.Caller.GetIdentity() == nil || req.Caller.GetIdentity().IsNil() {
 		// access token check is disabled => we can skip the authz service
 		if !c.authCfg.accessTokenAuthEnabled {
 			return true, nil
 		}
 
-		perms := req.Caller.AccessTokenClaims.Rest.Permissions
+		if req.Caller.GetAccess() == nil {
+			return false, ErrMissingCaller
+		}
+
+		perms := req.Caller.GetAccess().Permissions()
 		for _, p := range perms {
 			if p == req.Action {
 				return true, nil
@@ -235,13 +239,17 @@ func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, 
 		return false, nil
 	}
 
-	span.SetAttributes(attribute.String("subject", req.Caller.IDTokenClaims.Subject))
+	span.SetAttributes(attribute.String("subject", req.Caller.GetIdentity().Subject()))
 
 	// Only check the service permissions if the access token check is enabled
 	if c.authCfg.accessTokenAuthEnabled {
+		if req.Caller.GetAccess() == nil {
+			return false, ErrMissingCaller
+		}
+
 		// Make sure the service is allowed to perform the requested action
 		serviceIsAllowedAction := false
-		for _, p := range req.Caller.AccessTokenClaims.Rest.DelegatedPermissions {
+		for _, p := range req.Caller.GetAccess().DelegatedPermissions() {
 			if p == req.Action {
 				serviceIsAllowedAction = true
 				break
@@ -252,7 +260,7 @@ func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, 
 		}
 	}
 
-	res, err := c.retrievePermissions(ctx, req.StackID, req.Caller.IDTokenClaims.Subject, req.Action)
+	res, err := c.retrievePermissions(ctx, req.StackID, req.Caller.GetIdentity().Subject(), req.Action)
 	if err != nil {
 		span.RecordError(err)
 		return false, err
@@ -272,13 +280,18 @@ func (c *LegacyClientImpl) Check(ctx context.Context, req *CheckRequest) (bool, 
 	return res.Check(append(req.Contextual, *req.Resource)...), nil
 }
 
-// nolint:staticcheck
-func (c *LegacyClientImpl) validateNamespace(caller authn.CallerAuthInfo, stackID int64) bool {
+func (c *LegacyClientImpl) validateNamespace(caller claims.AuthInfo, stackID int64) bool {
 	expectedNamespace := c.namespaceFmt(stackID)
 
 	// Check both AccessToken and IDToken (if present) for namespace match
-	accessTokenMatch := !c.authCfg.accessTokenAuthEnabled || caller.AccessTokenClaims.Rest.NamespaceMatches(expectedNamespace)
-	idTokenMatch := caller.IDTokenClaims == nil || caller.IDTokenClaims.Rest.NamespaceMatches(expectedNamespace)
+	accessClaims := caller.GetAccess()
+	accessTokenMatch := !c.authCfg.accessTokenAuthEnabled ||
+		(accessClaims != nil && !accessClaims.IsNil() &&
+			(accessClaims.Namespace() == "*" || accessClaims.Namespace() == expectedNamespace))
+
+	idClaims := caller.GetIdentity()
+	idTokenMatch := idClaims == nil || idClaims.IsNil() ||
+		idClaims.Namespace() == "*" || idClaims.Namespace() == expectedNamespace
 
 	return accessTokenMatch && idTokenMatch
 }

--- a/authz/multitenant_client_test.go
+++ b/authz/multitenant_client_test.go
@@ -255,8 +255,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "No Caller",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller:  authn.CallerAuthInfo{},
+				Caller:  &authn.AuthInfo{},
 				StackID: 12,
 				Action:  "dashboards:read",
 			},
@@ -265,12 +264,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "Service does not have the action",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -280,12 +278,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "Service has the action",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", Permissions: []string{"dashboards:read"}},
-					},
+					}),
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -295,12 +292,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "Service has the action but in the wrong namespace",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-13", Permissions: []string{"dashboards:read"}},
-					},
+					}),
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -310,16 +306,15 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "On behalf of, service does not have the action",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12"},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+					}),
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -329,16 +324,15 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "On behalf of, service does have the action, but user not",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+					}),
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -348,16 +342,15 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "On behalf of, action check only",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+					}),
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -368,16 +361,15 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "On behalf of, action check only, user is in another namespaces",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "*", DelegatedPermissions: []string{"dashboards:read"}},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+					}),
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-13"},
-					},
+					}),
 				},
 				StackID: 12,
 				Action:  "dashboards:read",
@@ -387,16 +379,15 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "On behalf of, user has the action on another resource",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+					}),
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID:  12,
 				Action:   "dashboards:read",
@@ -408,16 +399,15 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "On behalf of, user has the action on the resource",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+					}),
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID:  12,
 				Action:   "dashboards:read",
@@ -429,16 +419,15 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 		{
 			name: "On behalf of, user has the action on the contextual resource",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+				Caller: &authn.AuthInfo{
+					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
 						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
-					},
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+					}),
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID:    12,
 				Action:     "dashboards:read",
@@ -472,16 +461,15 @@ func TestLegacyClientImpl_Check_OnPremFmt(t *testing.T) {
 	authz.res = &authzv1.ReadResponse{Found: true, Data: []*authzv1.ReadResponse_Data{{Object: "dashboards:uid:1"}}}
 
 	req := CheckRequest{
-		// nolint:staticcheck
-		Caller: authn.CallerAuthInfo{
-			AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+		Caller: &authn.AuthInfo{
+			AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 				Claims: &jwt.Claims{Subject: "service"},
 				Rest:   authn.AccessTokenClaims{Namespace: "default", DelegatedPermissions: []string{"dashboards:read"}},
-			},
-			IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+			}),
+			IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 				Claims: &jwt.Claims{Subject: "user:1"},
 				Rest:   authn.IDTokenClaims{Namespace: "default"},
-			},
+			}),
 		},
 		StackID:  1,
 		Action:   "dashboards:read",
@@ -498,16 +486,15 @@ func TestLegacyClientImpl_Check_Cache(t *testing.T) {
 	authz.res = &authzv1.ReadResponse{Found: true, Data: []*authzv1.ReadResponse_Data{{Object: "dashboards:uid:1"}}}
 
 	req := CheckRequest{
-		// nolint:staticcheck
-		Caller: authn.CallerAuthInfo{
-			AccessTokenClaims: authn.Claims[authn.AccessTokenClaims]{
+		Caller: &authn.AuthInfo{
+			AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 				Claims: &jwt.Claims{Subject: "service"},
 				Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
-			},
-			IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+			}),
+			IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 				Claims: &jwt.Claims{Subject: "user:1"},
 				Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-			},
+			}),
 		},
 		StackID:  12,
 		Action:   "dashboards:read",
@@ -571,8 +558,7 @@ func TestLegacyClientImpl_Check_DisableAccessToken(t *testing.T) {
 		{
 			name: "No user assume the service is allowed",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller:  authn.CallerAuthInfo{},
+				Caller:  &authn.AuthInfo{},
 				StackID: 12,
 				Action:  "dashboards:read",
 			},
@@ -581,12 +567,11 @@ func TestLegacyClientImpl_Check_DisableAccessToken(t *testing.T) {
 		{
 			name: "User has the action on the resource",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+				Caller: &authn.AuthInfo{
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID:  12,
 				Action:   "dashboards:read",
@@ -598,12 +583,11 @@ func TestLegacyClientImpl_Check_DisableAccessToken(t *testing.T) {
 		{
 			name: "User has the action on another resource",
 			req: CheckRequest{
-				// nolint:staticcheck
-				Caller: authn.CallerAuthInfo{
-					IDTokenClaims: &authn.Claims[authn.IDTokenClaims]{
+				Caller: &authn.AuthInfo{
+					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
 						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
-					},
+					}),
 				},
 				StackID:  12,
 				Action:   "dashboards:read",

--- a/claims/token.go
+++ b/claims/token.go
@@ -143,6 +143,8 @@ type IdentityClaims interface {
 
 	// Display Name of the user (name attribute if it is set, otherwise the login or email)
 	DisplayName() string
+
+	IsNil() bool
 }
 
 // Access claims indicate what the request can access independent from the identity
@@ -159,4 +161,6 @@ type AccessClaims interface {
 	Permissions() []string
 	// On-behalf-of user
 	DelegatedPermissions() []string
+
+	IsNil() bool
 }


### PR DESCRIPTION
Follow-up to https://github.com/grafana/authlib/pull/63

`authn.CallerAuthInfo` is being deprecated and replaced by `claims.AuthInfo`.