### PR TITLE
Pass authz's http client to verifier

### DIFF
--- a/authz/client.go
+++ b/authz/client.go
@@ -77,16 +77,16 @@ func newClient(cfg Config, opts ...clientOption) (*clientImpl, error) {
 		})
 	}
 
-	client.verifier = authn.NewVerifier[customClaims](
-		authn.VerifierConfig{},
-		authn.TokenTypeID,
-		authn.NewKeyRetriever(authn.KeyRetrieverConfig{SigningKeysURL: cfg.JWKsURL}),
-	)
-
 	// create httpClient, if not already present
 	if client.client == nil {
 		client.client = httpclient.New()
 	}
+
+	client.verifier = authn.NewVerifier[customClaims](
+		authn.VerifierConfig{},
+		authn.TokenTypeID,
+		authn.NewKeyRetriever(authn.KeyRetrieverConfig{SigningKeysURL: cfg.JWKsURL}, authn.WithHTTPClientKeyRetrieverOpt(client.client.(*http.Client))),
+	)
 
 	return client, nil
 }


### PR DESCRIPTION
The PR passes the HTTP client of `authz` to the `KeyRetriever`. This ensures any options passed to `authz` client will be passed to `KeyRetriever`. A common use case is to skip TLS checks in development environment where this option must be passed to `KeyRetriever` as well to ignore certificate errors while fetching signing keys.