### PR TITLE
NamespaceMapper: conform to cloud pluralized stacks-<id> namespace

### DIFF
--- a/authn/claims.go
+++ b/authn/claims.go
@@ -172,10 +172,7 @@ func (c *Identity) Username() string {
 
 // NamespaceMatches implements claims.IdentityClaims.
 func (c *Identity) NamespaceMatches(namespace string) bool {
-	if c.Namespace() == "*" {
-		return true
-	}
-	return c.Namespace() == namespace
+	return c.claims.Rest.NamespaceMatches(namespace)
 }
 
 // IsNil implements claims.IdentityClaims.
@@ -252,10 +249,7 @@ func (c *Access) Scopes() []string {
 
 // NamespaceMatches implements claims.AccessClaims.
 func (c *Access) NamespaceMatches(namespace string) bool {
-	if c.Namespace() == "*" {
-		return true
-	}
-	return c.Namespace() == namespace
+	return c.claims.Rest.NamespaceMatches(namespace)
 }
 
 // IsNil implements claims.AccessClaims.

--- a/authn/grpc_authenticator_test.go
+++ b/authn/grpc_authenticator_test.go
@@ -122,7 +122,7 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 				}
 				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
-					Rest:   IDTokenClaims{Namespace: "stack-12"},
+					Rest:   IDTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			want: AuthInfo{
@@ -132,7 +132,7 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 				}),
 				IdentityClaims: NewIdentityClaims(Claims[IDTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
-					Rest:   IDTokenClaims{Namespace: "stack-12"},
+					Rest:   IDTokenClaims{Namespace: "stacks-12"},
 				}),
 			},
 		},
@@ -188,11 +188,11 @@ func TestGrpcAuthenticator_Authenticate(t *testing.T) {
 			initEnv: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
-					Rest:   AccessTokenClaims{Namespace: "stack-13"},
+					Rest:   AccessTokenClaims{Namespace: "stacks-13"},
 				}
 				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
-					Rest:   IDTokenClaims{Namespace: "stack-12"},
+					Rest:   IDTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			wantErr: ErrorNamespacesMismatch,
@@ -263,7 +263,7 @@ func TestGrpcAuthenticator_authenticateService(t *testing.T) {
 			initEnv: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: "invalid-subject"},
-					Rest:   AccessTokenClaims{Namespace: "stack-12"},
+					Rest:   AccessTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			wantErr: ErrorInvalidSubject,
@@ -274,7 +274,7 @@ func TestGrpcAuthenticator_authenticateService(t *testing.T) {
 			initEnv: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAPIKey) + ":3"},
-					Rest:   AccessTokenClaims{Namespace: "stack-12"},
+					Rest:   AccessTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			wantErr: ErrorInvalidSubjectType,
@@ -285,12 +285,12 @@ func TestGrpcAuthenticator_authenticateService(t *testing.T) {
 			initEnv: func(env *testEnv) {
 				env.atVerifier.expectedClaims = &Claims[AccessTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
-					Rest:   AccessTokenClaims{Namespace: "stack-12"},
+					Rest:   AccessTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			want: &Claims[AccessTokenClaims]{
 				Claims: &jwt.Claims{Subject: string(typeAccessPolicy) + ":3"},
-				Rest:   AccessTokenClaims{Namespace: "stack-12"},
+				Rest:   AccessTokenClaims{Namespace: "stacks-12"},
 			},
 		},
 		{
@@ -353,7 +353,7 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 			initEnv: func(env *testEnv) {
 				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
 					Claims: &jwt.Claims{Subject: "invalid-subject"},
-					Rest:   IDTokenClaims{Namespace: "stack-12"},
+					Rest:   IDTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			wantErr: ErrorInvalidSubject,
@@ -364,7 +364,7 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 			initEnv: func(env *testEnv) {
 				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeAPIKey) + ":3"},
-					Rest:   IDTokenClaims{Namespace: "stack-12"},
+					Rest:   IDTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			wantErr: ErrorInvalidSubjectType,
@@ -375,12 +375,12 @@ func TestGrpcAuthenticator_authenticateUser(t *testing.T) {
 			initEnv: func(env *testEnv) {
 				env.idVerifier.expectedClaims = &Claims[IDTokenClaims]{
 					Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
-					Rest:   IDTokenClaims{Namespace: "stack-12"},
+					Rest:   IDTokenClaims{Namespace: "stacks-12"},
 				}
 			},
 			want: &Claims[IDTokenClaims]{
 				Claims: &jwt.Claims{Subject: string(typeUser) + ":3"},
-				Rest:   IDTokenClaims{Namespace: "stack-12"},
+				Rest:   IDTokenClaims{Namespace: "stacks-12"},
 			},
 		},
 	}

--- a/authn/token_exchange_test.go
+++ b/authn/token_exchange_test.go
@@ -98,7 +98,7 @@ func Test_TokenExchangeClient_Exchange(t *testing.T) {
 		require.Equal(t, 1, calls)
 
 		// different namespace should issue new token request
-		res, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stack-1", Audiences: []string{"some-service"}})
+		res, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stacks-1", Audiences: []string{"some-service"}})
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		require.Equal(t, 2, calls)

--- a/authn/verifier_access_token.go
+++ b/authn/verifier_access_token.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"context"
+	"strings"
 )
 
 type AccessTokenClaims struct {
@@ -16,11 +17,18 @@ type AccessTokenClaims struct {
 	DelegatedPermissions []string `json:"delegatedPermissions"`
 }
 
+// disambiguateNamespace is a helper to temporarily navigate the issue with cloud namespace claims being ambiguous (stack vs stacks).
+func disambiguateNamespace(namespace string) string {
+	return strings.Replace(namespace, "stack-", "stacks-", 1)
+}
+
 func (c AccessTokenClaims) NamespaceMatches(namespace string) bool {
-	if c.Namespace == "*" {
+	actual := disambiguateNamespace(c.Namespace)
+	expected := disambiguateNamespace(namespace)
+	if actual == "*" {
 		return true
 	}
-	return c.Namespace == namespace
+	return actual == expected
 }
 
 func NewAccessTokenVerifier(cfg VerifierConfig, keys KeyRetriever) *AccessTokenVerifier {

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -44,10 +44,10 @@ func (c IDTokenClaims) getK8sName() string {
 }
 
 func (c IDTokenClaims) NamespaceMatches(namespace string) bool {
-	if c.Namespace == "*" {
-		return true
-	}
-	return c.Namespace == namespace
+	actual := disambiguateNamespace(c.Namespace)
+	expected := disambiguateNamespace(namespace)
+
+	return actual == expected
 }
 
 func NewIDTokenVerifier(cfg VerifierConfig, keys KeyRetriever) *IDTokenVerifier {

--- a/authz/multitenant_client_test.go
+++ b/authz/multitenant_client_test.go
@@ -267,7 +267,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID: 12,
@@ -281,7 +281,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", Permissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", Permissions: []string{"dashboards:read"}},
 					}),
 				},
 				StackID: 12,
@@ -295,7 +295,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-13", Permissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-13", Permissions: []string{"dashboards:read"}},
 					}),
 				},
 				StackID: 12,
@@ -309,11 +309,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12"},
 					}),
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID: 12,
@@ -327,11 +327,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards:read"}},
 					}),
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID: 12,
@@ -345,11 +345,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards:read"}},
 					}),
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID: 12,
@@ -368,7 +368,7 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 					}),
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-13"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-13"},
 					}),
 				},
 				StackID: 12,
@@ -382,11 +382,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards:read"}},
 					}),
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID:  12,
@@ -402,11 +402,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards:read"}},
 					}),
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID:  12,
@@ -422,11 +422,11 @@ func TestLegacyClientImpl_Check(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 						Claims: &jwt.Claims{Subject: "service"},
-						Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
+						Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards:read"}},
 					}),
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID:    12,
@@ -489,11 +489,11 @@ func TestLegacyClientImpl_Check_Cache(t *testing.T) {
 		Caller: &authn.AuthInfo{
 			AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{
 				Claims: &jwt.Claims{Subject: "service"},
-				Rest:   authn.AccessTokenClaims{Namespace: "stack-12", DelegatedPermissions: []string{"dashboards:read"}},
+				Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards:read"}},
 			}),
 			IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 				Claims: &jwt.Claims{Subject: "user:1"},
-				Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+				Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 			}),
 		},
 		StackID:  12,
@@ -570,7 +570,7 @@ func TestLegacyClientImpl_Check_DisableAccessToken(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID:  12,
@@ -586,7 +586,7 @@ func TestLegacyClientImpl_Check_DisableAccessToken(t *testing.T) {
 				Caller: &authn.AuthInfo{
 					IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{
 						Claims: &jwt.Claims{Subject: "user:1"},
-						Rest:   authn.IDTokenClaims{Namespace: "stack-12"},
+						Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
 					}),
 				},
 				StackID:  12,

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -77,16 +76,14 @@ func WithDisableAccessTokenNamespaceAccessCheckerOption() NamespaceAccessChecker
 
 // NewNamespaceAuthorizer creates a new namespace authorizer.
 // If both ID token and access token are disabled, the authorizer will always return nil.
-func NewNamespaceAccessChecker(checkerType NamespaceAccessCheckerType, opts ...NamespaceAccessCheckerOption) (*NamespaceAccessCheckerImpl, error) {
+func NewNamespaceAccessChecker(checkerType NamespaceAccessCheckerType, opts ...NamespaceAccessCheckerOption) *NamespaceAccessCheckerImpl {
 	var namespaceFmt claims.NamespaceFormatter
 
 	switch checkerType {
 	case NamespaceAccessCheckerTypeCloud:
 		namespaceFmt = claims.CloudNamespaceFormatter
-	case NamespaceAccessCheckerTypeOrg:
-		namespaceFmt = claims.OrgNamespaceFormatter
 	default:
-		return nil, fmt.Errorf("invalid namespace access checker specified: %d", checkerType)
+		namespaceFmt = claims.OrgNamespaceFormatter
 	}
 
 	na := &NamespaceAccessCheckerImpl{
@@ -101,7 +98,7 @@ func NewNamespaceAccessChecker(checkerType NamespaceAccessCheckerType, opts ...N
 		opt(na)
 	}
 
-	return na, nil
+	return na
 }
 
 func (na *NamespaceAccessCheckerImpl) CheckAccess(caller claims.AuthInfo, expectedNamespace string) error {
@@ -221,7 +218,7 @@ func checkEqualsNamespaceDisambiguous(expectedNamespace, actualNamespace string,
 	if checkerType == NamespaceAccessCheckerTypeOrg {
 		return expectedNamespace == actualNamespace
 	}
-	
+
 	actualNamespaceParts := strings.Split(actualNamespace, "-")
 	if len(actualNamespaceParts) < 2 {
 		return false

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultStackIDMetadataKey = "X-stacks-ID"
+	DefaultStackIDMetadataKey = "X-Stack-ID"
 )
 
 var (

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultStackIDMetadataKey = "X-Stack-ID"
+	DefaultStackIDMetadataKey = "X-stacks-ID"
 )
 
 var (
@@ -34,7 +34,7 @@ type NamespaceAccessCheckerOption func(*NamespaceAccessCheckerImpl)
 
 type NamespaceAccessCheckerImpl struct {
 	// namespaceFmt is the namespace formatter used to generate the expected namespace.
-	// Ex: "stack-%d" -> "stack-12"
+	// Ex: "stacks-%d" -> "stacks-12"
 	namespaceFmt claims.NamespaceFormatter
 
 	// idTokenEnabled is a flag to enable ID token namespace validation.

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -132,7 +132,7 @@ func (na *NamespaceAccessCheckerImpl) CheckAccess(caller claims.AuthInfo, expect
 }
 
 // CheckAccessForIdentitfier uses the specified identifier to use with the namespace formatter
-// to generate the expected namespace from.
+// to generate the expected namespace which will be checked for access.
 func (na *NamespaceAccessCheckerImpl) CheckAccessForIdentitfier(caller claims.AuthInfo, id int64) error {
 	expectedNamespace := na.namespaceFmt(id)
 	return na.CheckAccess(caller, expectedNamespace)

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -218,6 +218,10 @@ func getFirstMetadataValue(md metadata.MD, key string) (string, bool) {
 
 // checkEqualsNamespaceDisambiguous is a helper to temporarily navigate the issue with cloud namespace claims being ambiguous.
 func checkEqualsNamespaceDisambiguous(expectedNamespace, actualNamespace string, checkerType NamespaceAccessCheckerType) bool {
+	if checkerType == NamespaceAccessCheckerTypeOrg {
+		return expectedNamespace == actualNamespace
+	}
+	
 	actualNamespaceParts := strings.Split(actualNamespace, "-")
 	if len(actualNamespaceParts) < 2 {
 		return false
@@ -229,10 +233,6 @@ func checkEqualsNamespaceDisambiguous(expectedNamespace, actualNamespace string,
 	}
 
 	if checkerType == NamespaceAccessCheckerTypeCloud && (actualNamespaceParts[0] == "stack" || actualNamespaceParts[0] == "stacks") && expectedNamespaceParts[0] == "stacks" {
-		return actualNamespaceParts[1] == expectedNamespaceParts[1]
-	}
-
-	if checkerType == NamespaceAccessCheckerTypeOrg && actualNamespaceParts[0] == "org" && expectedNamespaceParts[0] == "org" {
 		return actualNamespaceParts[1] == expectedNamespaceParts[1]
 	}
 

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -26,13 +26,6 @@ var (
 	ErrorAccessTokenNamespaceMismatch = status.Errorf(codes.PermissionDenied, "unauthorized: access token namespace does not match expected namespace")
 )
 
-type NamespaceAccessCheckerType int
-
-const (
-	NamespaceAccessCheckerTypeCloud NamespaceAccessCheckerType = iota + 1
-	NamespaceAccessCheckerTypeOrg
-)
-
 type NamespaceAccessChecker interface {
 	CheckAccess(caller claims.AuthInfo, namespace string) error
 	CheckAccessByID(caller claims.AuthInfo, id int64) error
@@ -43,7 +36,6 @@ var _ NamespaceAccessChecker = &NamespaceAccessCheckerImpl{}
 type NamespaceAccessCheckerOption func(*NamespaceAccessCheckerImpl)
 
 type NamespaceAccessCheckerImpl struct {
-	checkerType NamespaceAccessCheckerType
 	// namespaceFmt is the namespace formatter used to generate the expected namespace.
 	// Ex: "stacks-%d" -> "stacks-12"
 	namespaceFmt claims.NamespaceFormatter
@@ -75,18 +67,8 @@ func WithDisableAccessTokenNamespaceAccessCheckerOption() NamespaceAccessChecker
 
 // NewNamespaceAuthorizer creates a new namespace authorizer.
 // If both ID token and access token are disabled, the authorizer will always return nil.
-func NewNamespaceAccessChecker(checkerType NamespaceAccessCheckerType, opts ...NamespaceAccessCheckerOption) *NamespaceAccessCheckerImpl {
-	var namespaceFmt claims.NamespaceFormatter
-
-	switch checkerType {
-	case NamespaceAccessCheckerTypeCloud:
-		namespaceFmt = claims.CloudNamespaceFormatter
-	default:
-		namespaceFmt = claims.OrgNamespaceFormatter
-	}
-
+func NewNamespaceAccessChecker(namespaceFmt claims.NamespaceFormatter, opts ...NamespaceAccessCheckerOption) *NamespaceAccessCheckerImpl {
 	na := &NamespaceAccessCheckerImpl{
-		checkerType:        checkerType,
 		namespaceFmt:       namespaceFmt,
 		idTokenEnabled:     false,
 		idTokenRequired:    false,

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -148,6 +148,14 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			},
 		},
 		{
+			name:        "id token and access token (with wildcard namespace) match",
+			checkerType: NamespaceAccessCheckerTypeCloud,
+			caller: &authn.AuthInfo{
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
+				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}}),
+			},
+		},
+		{
 			name:        "id token and access token match for org checker",
 			checkerType: NamespaceAccessCheckerTypeOrg,
 			caller: &authn.AuthInfo{
@@ -160,6 +168,22 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			checkerType: NamespaceAccessCheckerTypeCloud,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
+				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
+			},
+		},
+		{
+			name:        "id token (deprecated value) and access token match",
+			checkerType: NamespaceAccessCheckerTypeCloud,
+			caller: &authn.AuthInfo{
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
+				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
+			},
+		},
+		{
+			name:        "id token and access token (deprecated value) match",
+			checkerType: NamespaceAccessCheckerTypeCloud,
+			caller: &authn.AuthInfo{
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
 			},
 		},

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -2,6 +2,7 @@ package authz
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,7 +52,7 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.nsFmt)
-			require.ErrorIs(t, na.CheckAccess(tt.caller, stackID), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccessForIdentitfier(tt.caller, stackID), tt.wantErr)
 		})
 	}
 }
@@ -89,7 +90,7 @@ func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.nsFmt, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
-			require.ErrorIs(t, na.CheckAccess(tt.caller, stackID), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccessForIdentitfier(tt.caller, stackID), tt.wantErr)
 		})
 	}
 }
@@ -147,7 +148,8 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.nsFmt, WithIDTokenNamespaceAccessCheckerOption(false))
-			require.ErrorIs(t, na.CheckAccess(tt.caller, stackID), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccess(tt.caller, fmt.Sprintf("stack-%d", stackID)), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccess(tt.caller, fmt.Sprintf("stacks-%d", stackID)), tt.wantErr)
 		})
 	}
 }

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -73,7 +73,7 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.checkerType)
-			require.ErrorIs(t, na.CheckAccessForIdentitfier(tt.caller, stackID), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccessByID(tt.caller, stackID), tt.wantErr)
 		})
 	}
 }
@@ -126,7 +126,7 @@ func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.checkerType, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
-			require.ErrorIs(t, na.CheckAccessForIdentitfier(tt.caller, identifier), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccessByID(tt.caller, identifier), tt.wantErr)
 		})
 	}
 }

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -29,7 +29,7 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 			name:  "access token match",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
+				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 		{
@@ -43,7 +43,7 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 			name:  "access token mismatch",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-13"}}),
+				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-13"}}),
 			},
 			wantErr: ErrorAccessTokenNamespaceMismatch,
 		},
@@ -74,14 +74,14 @@ func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 			name:  "id token match",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 		{
 			name:  "id token mismatch",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-13"}}),
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-13"}}),
 			},
 			wantErr: ErrorIDTokenNamespaceMismatch,
 		},
@@ -106,15 +106,15 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			name:  "id token and access token match",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
-				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
+				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 		{
 			name:  "id token and access token wildcard match",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}}),
 			},
 		},
@@ -122,8 +122,8 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			name:  "access token mismatch",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
-				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-13"}}),
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
+				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-13"}}),
 			},
 			wantErr: ErrorAccessTokenNamespaceMismatch,
 		},
@@ -131,8 +131,8 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			name:  "id token mismatch",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-13"}}),
-				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
+				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-13"}}),
+				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
 			wantErr: ErrorIDTokenNamespaceMismatch,
 		},
@@ -140,7 +140,7 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			name:  "id token missing but not required",
 			nsFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
-				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
+				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 	}
@@ -153,7 +153,7 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 }
 
 func TestMetadataStackIDExtractor(t *testing.T) {
-	key := "X-Stack-ID"
+	key := "X-stacks-ID"
 	tests := []struct {
 		name string
 		init func(context.Context) context.Context

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -209,7 +209,7 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 }
 
 func TestMetadataStackIDExtractor(t *testing.T) {
-	key := "X-stacks-ID"
+	key := "X-Stack-ID"
 	tests := []struct {
 		name string
 		init func(context.Context) context.Context

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -72,8 +72,7 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na, err := NewNamespaceAccessChecker(tt.checkerType)
-			require.NoError(t, err)
+			na := NewNamespaceAccessChecker(tt.checkerType)
 			require.ErrorIs(t, na.CheckAccessForIdentitfier(tt.caller, stackID), tt.wantErr)
 		})
 	}
@@ -126,8 +125,7 @@ func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na, err := NewNamespaceAccessChecker(tt.checkerType, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
-			require.NoError(t, err)
+			na := NewNamespaceAccessChecker(tt.checkerType, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
 			require.ErrorIs(t, na.CheckAccessForIdentitfier(tt.caller, identifier), tt.wantErr)
 		})
 	}
@@ -201,8 +199,7 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na, err := NewNamespaceAccessChecker(tt.checkerType, WithIDTokenNamespaceAccessCheckerOption(false))
-			require.NoError(t, err)
+			na := NewNamespaceAccessChecker(tt.checkerType, WithIDTokenNamespaceAccessCheckerOption(false))
 			require.ErrorIs(t, na.CheckAccess(tt.caller, na.namespaceFmt(identitifer)), tt.wantErr)
 		})
 	}

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -14,56 +14,56 @@ import (
 func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	stackID := int64(12)
 	tests := []struct {
-		name        string
-		checkerType NamespaceAccessCheckerType
-		caller      claims.AuthInfo
-		wantErr     error
+		name         string
+		namespaceFmt claims.NamespaceFormatter
+		caller       claims.AuthInfo
+		wantErr      error
 	}{
 		{
-			name:        "missing access token",
-			checkerType: NamespaceAccessCheckerTypeCloud,
-			caller:      &authn.AuthInfo{},
-			wantErr:     ErrorMissingAccessToken,
+			name:         "missing access token",
+			namespaceFmt: claims.CloudNamespaceFormatter,
+			caller:       &authn.AuthInfo{},
+			wantErr:      ErrorMissingAccessToken,
 		},
 		{
-			name:        "access token match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "access token match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 		{
-			name:        "access token match for org checker",
-			checkerType: NamespaceAccessCheckerTypeOrg,
+			name:         "access token match for org checker",
+			namespaceFmt: claims.OrgNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "org-12"}}),
 			},
 		},
 		{
-			name:        "access token wildcard match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "access token wildcard match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}}),
 			},
 		},
 		{
-			name:        "access token wildcard match for org checker",
-			checkerType: NamespaceAccessCheckerTypeOrg,
+			name:         "access token wildcard match for org checker",
+			namespaceFmt: claims.OrgNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}}),
 			},
 		},
 		{
-			name:        "access token mismatch",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "access token mismatch",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-13"}}),
 			},
 			wantErr: ErrorAccessTokenNamespaceMismatch,
 		},
 		{
-			name:        "access token mismatch for org checker",
-			checkerType: NamespaceAccessCheckerTypeOrg,
+			name:         "access token mismatch for org checker",
+			namespaceFmt: claims.OrgNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "org-13"}}),
 			},
@@ -72,7 +72,7 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na := NewNamespaceAccessChecker(tt.checkerType)
+			na := NewNamespaceAccessChecker(tt.namespaceFmt)
 			require.ErrorIs(t, na.CheckAccessByID(tt.caller, stackID), tt.wantErr)
 		})
 	}
@@ -81,42 +81,42 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 	identifier := int64(12)
 	tests := []struct {
-		name        string
-		checkerType NamespaceAccessCheckerType
-		caller      claims.AuthInfo
-		wantErr     error
+		name         string
+		namespaceFmt claims.NamespaceFormatter
+		caller       claims.AuthInfo
+		wantErr      error
 	}{
 		{
-			name:        "missing id token",
-			checkerType: NamespaceAccessCheckerTypeCloud,
-			caller:      &authn.AuthInfo{},
-			wantErr:     ErrorMissingIDToken,
+			name:         "missing id token",
+			namespaceFmt: claims.CloudNamespaceFormatter,
+			caller:       &authn.AuthInfo{},
+			wantErr:      ErrorMissingIDToken,
 		},
 		{
-			name:        "id token match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 		{
-			name:        "id token match for org checker",
-			checkerType: NamespaceAccessCheckerTypeOrg,
+			name:         "id token match for org checker",
+			namespaceFmt: claims.OrgNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "org-12"}}),
 			},
 		},
 		{
-			name:        "id token mismatch",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token mismatch",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-13"}}),
 			},
 			wantErr: ErrorIDTokenNamespaceMismatch,
 		},
 		{
-			name:        "id token mismatch for org checker",
-			checkerType: NamespaceAccessCheckerTypeOrg,
+			name:         "id token mismatch for org checker",
+			namespaceFmt: claims.OrgNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "org-13"}}),
 			},
@@ -125,7 +125,7 @@ func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na := NewNamespaceAccessChecker(tt.checkerType, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
+			na := NewNamespaceAccessChecker(tt.namespaceFmt, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
 			require.ErrorIs(t, na.CheckAccessByID(tt.caller, identifier), tt.wantErr)
 		})
 	}
@@ -134,70 +134,70 @@ func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 	identitifer := int64(12)
 	tests := []struct {
-		name        string
-		checkerType NamespaceAccessCheckerType
-		caller      claims.AuthInfo
-		wantErr     error
+		name         string
+		namespaceFmt claims.NamespaceFormatter
+		caller       claims.AuthInfo
+		wantErr      error
 	}{
 		{
-			name:        "id token and access token match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token and access token match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 		{
-			name:        "id token and access token (with wildcard namespace) match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token and access token (with wildcard namespace) match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}}),
 			},
 		},
 		{
-			name:        "id token and access token match for org checker",
-			checkerType: NamespaceAccessCheckerTypeOrg,
+			name:         "id token and access token match for org checker",
+			namespaceFmt: claims.OrgNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "org-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "org-12"}}),
 			},
 		},
 		{
-			name:        "id token and access token match deprecated values",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token and access token match deprecated values",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
 			},
 		},
 		{
-			name:        "id token (deprecated value) and access token match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token (deprecated value) and access token match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stack-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
 		},
 		{
-			name:        "id token and access token (deprecated value) match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token and access token (deprecated value) match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stack-12"}}),
 			},
 		},
 		{
-			name:        "id token and access token wildcard match",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token and access token wildcard match",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "*"}}),
 			},
 		},
 		{
-			name:        "access token mismatch",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "access token mismatch",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-12"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-13"}}),
@@ -205,8 +205,8 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			wantErr: ErrorAccessTokenNamespaceMismatch,
 		},
 		{
-			name:        "id token mismatch",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token mismatch",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				IdentityClaims: authn.NewIdentityClaims(authn.Claims[authn.IDTokenClaims]{Rest: authn.IDTokenClaims{Namespace: "stacks-13"}}),
 				AccessClaims:   authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
@@ -214,8 +214,8 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 			wantErr: ErrorIDTokenNamespaceMismatch,
 		},
 		{
-			name:        "id token missing but not required",
-			checkerType: NamespaceAccessCheckerTypeCloud,
+			name:         "id token missing but not required",
+			namespaceFmt: claims.CloudNamespaceFormatter,
 			caller: &authn.AuthInfo{
 				AccessClaims: authn.NewAccessClaims(authn.Claims[authn.AccessTokenClaims]{Rest: authn.AccessTokenClaims{Namespace: "stacks-12"}}),
 			},
@@ -223,7 +223,7 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			na := NewNamespaceAccessChecker(tt.checkerType, WithIDTokenNamespaceAccessCheckerOption(false))
+			na := NewNamespaceAccessChecker(tt.namespaceFmt, WithIDTokenNamespaceAccessCheckerOption(false))
 			require.ErrorIs(t, na.CheckAccess(tt.caller, na.namespaceFmt(identitifer)), tt.wantErr)
 		})
 	}

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -60,6 +60,7 @@ func ParseNamespace(ns string) (NamespaceInfo, error) {
 		}
 		info.StackID = stackID
 		info.OrgID = 1
+		return info, err
 	}
 
 	// handle deprecated stack-X value
@@ -70,7 +71,8 @@ func ParseNamespace(ns string) (NamespaceInfo, error) {
 		}
 		info.StackID = stackID
 		info.OrgID = 1
+		return info, err
 	}
 
-	return info, nil
+	return info, fmt.Errorf("namespace didn't parse to a legal value: raw=%s", info.Value)
 }

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -12,7 +12,8 @@ import (
 type NamespaceFormatter func(int64) string
 
 func CloudNamespaceFormatter(id int64) string {
-	return fmt.Sprintf("stacks-%d", id)
+	// TODO: change this to stacks-X when all the other dependent pieces (gcom etc.) can validate both stack-x and stacks-X
+	return fmt.Sprintf("stack-%d", id)
 }
 
 // OrgNamespaceFormatter is the namespace format used in on-prem deployments

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -8,7 +8,7 @@ import (
 
 // NamespaceFormatter defines a function that formats a stack or organization ID
 // into the expected namespace format based on the deployment environment (Cloud/On-prem).
-// Example: stacks-6481, org-12
+// Example: stack-6481, org-12
 type NamespaceFormatter func(int64) string
 
 func CloudNamespaceFormatter(id int64) string {

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -11,7 +11,7 @@ import (
 // Example: stack-6481, org-12
 type NamespaceFormatter func(int64) string
 
-func CloudNamespaceFormatter(id string) string {
+func CloudNamespaceFormatter(id int64) string {
 	return fmt.Sprintf("stacks-%d", id)
 }
 
@@ -31,7 +31,7 @@ type NamespaceInfo struct {
 	OrgID int64
 
 	// The cloud stack ID (must match the value in cfg.Settings)
-	StackID string
+	StackID int64
 }
 
 func ParseNamespace(ns string) (NamespaceInfo, error) {
@@ -55,7 +55,11 @@ func ParseNamespace(ns string) (NamespaceInfo, error) {
 
 	if strings.HasPrefix(ns, "stacks-") {
 		stackIDStr := ns[6:]
-		info.StackID = stackIDStr
+		stackId, err := strconv.Atoi(stackIDStr)
+		if err != nil {
+			return info, err
+		}
+		info.StackID = int64(stackId)
 		info.OrgID = 1
 		return info, nil
 	}

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -11,8 +11,8 @@ import (
 // Example: stack-6481, org-12
 type NamespaceFormatter func(int64) string
 
-func CloudNamespaceFormatter(id int64) string {
-	return fmt.Sprintf("stack-%d", id)
+func CloudNamespaceFormatter(id string) string {
+	return fmt.Sprintf("stacks-%d", id)
 }
 
 // OrgNamespaceFormatter is the namespace format used in on-prem deployments
@@ -31,7 +31,7 @@ type NamespaceInfo struct {
 	OrgID int64
 
 	// The cloud stack ID (must match the value in cfg.Settings)
-	StackID int64
+	StackID string
 }
 
 func ParseNamespace(ns string) (NamespaceInfo, error) {
@@ -53,13 +53,9 @@ func ParseNamespace(ns string) (NamespaceInfo, error) {
 		return info, err
 	}
 
-	if strings.HasPrefix(ns, "stack-") {
+	if strings.HasPrefix(ns, "stacks-") {
 		stackIDStr := ns[6:]
-		stackID, err := strconv.ParseInt(stackIDStr, 10, 64)
-		if err != nil || stackID < 1 {
-			return info, fmt.Errorf("invalid stack id")
-		}
-		info.StackID = stackID
+		info.StackID = stackIDStr
 		info.OrgID = 1
 		return info, nil
 	}

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -53,15 +53,24 @@ func ParseNamespace(ns string) (NamespaceInfo, error) {
 		return info, err
 	}
 
-	if strings.HasPrefix(ns, "stacks-") {
-		stackIDStr := ns[6:]
-		stackId, err := strconv.Atoi(stackIDStr)
-		if err != nil {
-			return info, err
+	if id, ok := strings.CutPrefix(ns, "stacks-"); ok {
+		stackID, err := strconv.ParseInt(id, 10, 64)
+		if err != nil || stackID < 1 {
+			return info, fmt.Errorf("invalid stack id")
 		}
-		info.StackID = int64(stackId)
+		info.StackID = stackID
 		info.OrgID = 1
-		return info, nil
 	}
+
+	// handle deprecated stack-X value
+	if id, ok := strings.CutPrefix(ns, "stack-"); ok {
+		stackID, err := strconv.ParseInt(id, 10, 64)
+		if err != nil || stackID < 1 {
+			return info, fmt.Errorf("invalid stack id")
+		}
+		info.StackID = stackID
+		info.OrgID = 1
+	}
+
 	return info, nil
 }

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -8,7 +8,7 @@ import (
 
 // NamespaceFormatter defines a function that formats a stack or organization ID
 // into the expected namespace format based on the deployment environment (Cloud/On-prem).
-// Example: stack-6481, org-12
+// Example: stacks-6481, org-12
 type NamespaceFormatter func(int64) string
 
 func CloudNamespaceFormatter(id int64) string {

--- a/claims/namespace_test.go
+++ b/claims/namespace_test.go
@@ -14,7 +14,8 @@ func TestParseNamespace(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name: "empty namespace",
+			name:      "empty namespace",
+			expectErr: true,
 			expected: claims.NamespaceInfo{
 				OrgID: -1,
 			},
@@ -128,6 +129,7 @@ func TestParseNamespace(t *testing.T) {
 				OrgID: -1,
 				Value: "anything",
 			},
+			expectErr: true,
 		},
 	}
 

--- a/claims/namespace_test.go
+++ b/claims/namespace_test.go
@@ -76,14 +76,14 @@ func TestParseNamespace(t *testing.T) {
 		{
 			name:      "invalid stack id (must be an int)",
 			expectErr: true,
-			namespace: "stack-abcdef",
+			namespace: "stacks-abcdef",
 			expected: claims.NamespaceInfo{
 				OrgID: -1,
 			},
 		},
 		{
 			name:      "invalid stack id (must be provided)",
-			namespace: "stack-",
+			namespace: "stacks-",
 			expectErr: true,
 			expected: claims.NamespaceInfo{
 				OrgID: -1,
@@ -91,7 +91,7 @@ func TestParseNamespace(t *testing.T) {
 		},
 		{
 			name:      "invalid stack id (cannot be 0)",
-			namespace: "stack-0",
+			namespace: "stacks-0",
 			expectErr: true,
 			expected: claims.NamespaceInfo{
 				OrgID: -1,
@@ -99,7 +99,7 @@ func TestParseNamespace(t *testing.T) {
 		},
 		{
 			name:      "valid stack",
-			namespace: "stack-1",
+			namespace: "stacks-1",
 			expected: claims.NamespaceInfo{
 				OrgID:   1,
 				StackID: 1,

--- a/claims/namespace_test.go
+++ b/claims/namespace_test.go
@@ -82,6 +82,14 @@ func TestParseNamespace(t *testing.T) {
 			},
 		},
 		{
+			name:      "invalid stack id in deprecated claim (must be an int)",
+			expectErr: true,
+			namespace: "stack-abcdef",
+			expected: claims.NamespaceInfo{
+				OrgID: -1,
+			},
+		},
+		{
 			name:      "invalid stack id (must be provided)",
 			namespace: "stacks-",
 			expectErr: true,
@@ -100,6 +108,14 @@ func TestParseNamespace(t *testing.T) {
 		{
 			name:      "valid stack",
 			namespace: "stacks-1",
+			expected: claims.NamespaceInfo{
+				OrgID:   1,
+				StackID: 1,
+			},
+		},
+		{
+			name:      "valid stack is read from deprecated claim",
+			namespace: "stack-1",
 			expected: claims.NamespaceInfo{
 				OrgID:   1,
 				StackID: 1,


### PR DESCRIPTION
There has been some miscommunication within our working group and it made its way into OSS code and into auth/authlib, which is that cloud namespace format is `stack-<stackID>`.

This is incorrect. Cloud namespaces are `stacks-<stackId>` historically.

[Slack convo](https://raintank-corp.slack.com/archives/C037H5GAY9L/p1724257160817399?thread_ts=1722433605.876979&cid=C037H5GAY9L).

This change-set tries to take care of the problem in a backwards-compatible way. In talking with @kalleep, we decided to treat both `stack-<stackId>` and `stacks-<stackId>` as valid for the time being.

While I was at it, I was very happy to see that something like NamespaceAccessChecker exists. I would love to use it for some use-cases but its reliance on me knowing `stackID` was something discouraging due to the chicken-in-egg issue arising from the plural vs singular stack namespaces.

I changed the interface slightly to just take a string `expectedNamespace` and moved the older contract to the more general `CheckAccessForIdentitfier(caller, identifier)`, so it could be used for stackId or orgId.

Very open to feedback since this library is not under my purview. Thanks for considering any changes that you may from the PR.