### PR TITLE
Move the namespace matches outside of access/id implementations

### DIFF
--- a/authn/claims.go
+++ b/authn/claims.go
@@ -170,11 +170,6 @@ func (c *Identity) Username() string {
 	return c.claims.Rest.Username
 }
 
-// NamespaceMatches implements claims.IdentityClaims.
-func (c *Identity) NamespaceMatches(namespace string) bool {
-	return c.claims.Rest.NamespaceMatches(namespace)
-}
-
 // IsNil implements claims.IdentityClaims.
 func (c *Identity) IsNil() bool {
 	return c == nil
@@ -245,11 +240,6 @@ func (c *Access) Permissions() []string {
 // Scopes implements claims.AccessClaims.
 func (c *Access) Scopes() []string {
 	return c.claims.Rest.Scopes
-}
-
-// NamespaceMatches implements claims.AccessClaims.
-func (c *Access) NamespaceMatches(namespace string) bool {
-	return c.claims.Rest.NamespaceMatches(namespace)
 }
 
 // IsNil implements claims.AccessClaims.

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -154,7 +154,7 @@ func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context,
 		identityToken := authInfo.GetIdentity()
 
 		if !accessToken.IsNil() && !identityToken.IsNil() {
-			if !accessToken.NamespaceMatches(identityToken.Namespace()) {
+			if !claims.NamespaceMatches(accessToken, identityToken.Namespace()) {
 				return nil, ErrorNamespacesMismatch
 			}
 		}

--- a/authn/verifier_access_token.go
+++ b/authn/verifier_access_token.go
@@ -2,7 +2,6 @@ package authn
 
 import (
 	"context"
-	"strings"
 )
 
 type AccessTokenClaims struct {
@@ -15,20 +14,6 @@ type AccessTokenClaims struct {
 	Permissions []string `json:"permissions"`
 	// On-behalf-of user
 	DelegatedPermissions []string `json:"delegatedPermissions"`
-}
-
-// disambiguateNamespace is a helper to temporarily navigate the issue with cloud namespace claims being ambiguous (stack vs stacks).
-func disambiguateNamespace(namespace string) string {
-	return strings.Replace(namespace, "stack-", "stacks-", 1)
-}
-
-func (c AccessTokenClaims) NamespaceMatches(namespace string) bool {
-	actual := disambiguateNamespace(c.Namespace)
-	expected := disambiguateNamespace(namespace)
-	if actual == "*" {
-		return true
-	}
-	return actual == expected
 }
 
 func NewAccessTokenVerifier(cfg VerifierConfig, keys KeyRetriever) *AccessTokenVerifier {

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -43,13 +43,6 @@ func (c IDTokenClaims) getK8sName() string {
 	return c.Identifier
 }
 
-func (c IDTokenClaims) NamespaceMatches(namespace string) bool {
-	actual := disambiguateNamespace(c.Namespace)
-	expected := disambiguateNamespace(namespace)
-
-	return actual == expected
-}
-
 func NewIDTokenVerifier(cfg VerifierConfig, keys KeyRetriever) *IDTokenVerifier {
 	return &IDTokenVerifier{
 		v: NewVerifier[IDTokenClaims](cfg, TokenTypeID, keys),

--- a/authz/multitenant_client.go
+++ b/authz/multitenant_client.go
@@ -289,10 +289,10 @@ func (c *LegacyClientImpl) validateNamespace(caller claims.AuthInfo, stackID int
 	// Check both AccessToken and IDToken (if present) for namespace match
 	accessClaims := caller.GetAccess()
 	accessTokenMatch := !c.authCfg.accessTokenAuthEnabled ||
-		(accessClaims != nil && !accessClaims.IsNil() && accessClaims.NamespaceMatches(expectedNamespace))
+		(accessClaims != nil && !accessClaims.IsNil() && claims.NamespaceMatches(accessClaims, expectedNamespace))
 
 	idClaims := caller.GetIdentity()
-	idTokenMatch := idClaims == nil || idClaims.IsNil() || idClaims.NamespaceMatches(expectedNamespace)
+	idTokenMatch := idClaims == nil || idClaims.IsNil() || claims.NamespaceMatches(idClaims, expectedNamespace)
 
 	return accessTokenMatch && idTokenMatch
 }

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -92,7 +92,7 @@ func (na *NamespaceAccessCheckerImpl) CheckAccess(caller claims.AuthInfo, expect
 			// for else-if branch below,
 			// when id token claims are evaluated with an access token claims (with wildcard namespace) present
 			// but expectedNamespace is *, we skip the namespace equality check since it will always fail
-		} else if expectedNamespace != "*" && !idClaims.NamespaceMatches(expectedNamespace) {
+		} else if expectedNamespace != "*" && !claims.NamespaceMatches(idClaims, expectedNamespace) {
 			return ErrorIDTokenNamespaceMismatch
 		}
 	}
@@ -104,7 +104,7 @@ func (na *NamespaceAccessCheckerImpl) CheckAccess(caller claims.AuthInfo, expect
 		// for if branch below,
 		// when access token claims with a wildcard namespace are passed in, we skip the namespace equality check
 		// it **will fail** when checking on resources in specific namespaces, which we don't want
-		if !accessClaims.NamespaceMatches(expectedNamespace) {
+		if !claims.NamespaceMatches(accessClaims, expectedNamespace) {
 			return ErrorAccessTokenNamespaceMismatch
 		}
 	}

--- a/claims/namespace.go
+++ b/claims/namespace.go
@@ -24,6 +24,21 @@ func OrgNamespaceFormatter(id int64) string {
 	return fmt.Sprintf("org-%d", id)
 }
 
+// disambiguateNamespace is a helper to temporarily navigate the issue with cloud namespace claims being ambiguous (stack vs stacks).
+func disambiguateNamespace(namespace string) string {
+	return strings.Replace(namespace, "stack-", "stacks-", 1)
+}
+
+func NamespaceMatches(c Namespaced, namespace string) bool {
+	actual := disambiguateNamespace(c.Namespace())
+	expected := disambiguateNamespace(namespace)
+	// actual should never be a "*" where ID token claims are concerned
+	if actual == "*" {
+		return true
+	}
+	return actual == expected
+}
+
 type NamespaceInfo struct {
 	// The original namespace string regardless the input
 	Value string

--- a/claims/token.go
+++ b/claims/token.go
@@ -113,8 +113,16 @@ type TokenClaims interface {
 	JTI() string
 }
 
+type Namespaced interface {
+	// Namespace takes the form of '<type>-<id>', '*' means all namespaces.
+	// In grafana the can be either org or stack.
+	// The claims are valid within this namespace
+	Namespace() string
+}
+
 type IdentityClaims interface {
 	TokenClaims
+	Namespaced
 
 	// Type indicates what kind of identity this is
 	IdentityType() IdentityType
@@ -122,11 +130,6 @@ type IdentityClaims interface {
 	// Identifier is a unique identifier for this IdentityType within a namespace.
 	// For some identity types this can be empty e.g. Anonymous.
 	Identifier() string
-
-	// Namespace takes the form of '<type>-<id>', '*' means all namespaces.
-	// In grafana the can be either org or stack.
-	// The claims are valid within this namespace
-	Namespace() string
 
 	// AuthenticatedBy is the method used to authenticate the identity.
 	// Examples: password, oauth_azuread, etc
@@ -144,18 +147,14 @@ type IdentityClaims interface {
 	// Display Name of the user (name attribute if it is set, otherwise the login or email)
 	DisplayName() string
 
-	NamespaceMatches(namespace string) bool
 	IsNil() bool
 }
 
 // Access claims indicate what the request can access independent from the identity
 type AccessClaims interface {
 	TokenClaims
+	Namespaced
 
-	// Namespace takes the form of '<type>-<id>', '*' means all namespaces.
-	// In grafana the can be either org or stack.
-	// The claims are valid within this namespace
-	Namespace() string
 	// Access policy scopes
 	Scopes() []string
 	// Grafana roles
@@ -163,6 +162,5 @@ type AccessClaims interface {
 	// On-behalf-of user
 	DelegatedPermissions() []string
 
-	NamespaceMatches(namespace string) bool
 	IsNil() bool
 }


### PR DESCRIPTION
In collaboration with @ryantxu.