### PR TITLE
Add Tracing to Namespace Checker

### DIFF
--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -275,6 +276,7 @@ func newGrpcAuthenticatorCommon(cfg *GrpcAuthenticatorConfig, opts ...GrpcAuthen
 	}
 
 	if ga.tracer == nil {
+		ga.tracer = noop.NewTracerProvider().Tracer("authn.GrpcAuthenticator")
 		ga.tracer = otel.Tracer("authn.GrpcAuthenticator")
 	}
 

--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -8,7 +8,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -276,7 +275,6 @@ func newGrpcAuthenticatorCommon(cfg *GrpcAuthenticatorConfig, opts ...GrpcAuthen
 	}
 
 	if ga.tracer == nil {
-		ga.tracer = noop.NewTracerProvider().Tracer("authn.GrpcAuthenticator")
 		ga.tracer = otel.Tracer("authn.GrpcAuthenticator")
 	}
 

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -166,6 +166,7 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 			return ctx, err
 		}
 
+		span.SetAttributes(attribute.Bool("with_accesstoken", true))
 		md.Set(gci.cfg.AccessTokenMetadataKey, token.Token)
 	}
 

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/codes"
@@ -97,6 +98,7 @@ func NewNamespaceAccessChecker(namespaceFmt claims.NamespaceFormatter, opts ...N
 func (na *NamespaceAccessCheckerImpl) CheckAccess(ctx context.Context, caller claims.AuthInfo, expectedNamespace string) error {
 	_, span := na.tracer.Start(ctx, "NamespaceAccessChecker.CheckAccess")
 	defer span.End()
+	span.SetAttributes(attribute.String("expectedNamespace", expectedNamespace))
 
 	if na.idTokenEnabled {
 		idClaims := caller.GetIdentity()

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strconv"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -88,7 +88,7 @@ func NewNamespaceAccessChecker(namespaceFmt claims.NamespaceFormatter, opts ...N
 	}
 
 	if na.tracer == nil {
-		na.tracer = noop.NewTracerProvider().Tracer("authn.NamespaceAccessChecker")
+		na.tracer = otel.Tracer("authn.NamespaceAccessChecker")
 	}
 
 	return na

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strconv"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -88,7 +88,7 @@ func NewNamespaceAccessChecker(namespaceFmt claims.NamespaceFormatter, opts ...N
 	}
 
 	if na.tracer == nil {
-		na.tracer = otel.Tracer("authn.NamespaceAccessChecker")
+		na.tracer = noop.NewTracerProvider().Tracer("authn.NamespaceAccessChecker")
 	}
 
 	return na

--- a/authz/namespace.go
+++ b/authz/namespace.go
@@ -89,7 +89,7 @@ func NewNamespaceAccessChecker(namespaceFmt claims.NamespaceFormatter, opts ...N
 	}
 
 	if na.tracer == nil {
-		na.tracer = noop.NewTracerProvider().Tracer("authn.NamespaceAccessChecker")
+		na.tracer = noop.Tracer{}
 	}
 
 	return na

--- a/authz/namespace_test.go
+++ b/authz/namespace_test.go
@@ -73,7 +73,7 @@ func TestNamespaceAccessCheckerImpl_ValidateAccessTokenOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.namespaceFmt)
-			require.ErrorIs(t, na.CheckAccessByID(tt.caller, stackID), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccessByID(context.Background(), tt.caller, stackID), tt.wantErr)
 		})
 	}
 }
@@ -126,7 +126,7 @@ func TestNamespaceAccessCheckerImpl_ValidateIDTokenOnly(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.namespaceFmt, WithIDTokenNamespaceAccessCheckerOption(true), WithDisableAccessTokenNamespaceAccessCheckerOption())
-			require.ErrorIs(t, na.CheckAccessByID(tt.caller, identifier), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccessByID(context.Background(), tt.caller, identifier), tt.wantErr)
 		})
 	}
 }
@@ -224,7 +224,7 @@ func TestNamespaceAccessCheckerImpl_ValidateBoth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			na := NewNamespaceAccessChecker(tt.namespaceFmt, WithIDTokenNamespaceAccessCheckerOption(false))
-			require.ErrorIs(t, na.CheckAccess(tt.caller, na.namespaceFmt(identitifer)), tt.wantErr)
+			require.ErrorIs(t, na.CheckAccess(context.Background(), tt.caller, na.namespaceFmt(identitifer)), tt.wantErr)
 		})
 	}
 }


### PR DESCRIPTION
This PR enhances the namespace checker with tracing capabilities.

**Key changes:**
* Introduces tracing to the namespace checker.
* A noop tracer is used by default, ensuring no performance overhead when tracing is disabled.
* Provides the option to configure a custom tracer.
* Modifies the signature of CheckAccess to accept a context object, enabling trace propagation.
