### PR TITLE
Adjust AccessClient interface

### DIFF
--- a/claims/access.go
+++ b/claims/access.go
@@ -2,6 +2,14 @@ package claims
 
 import "context"
 
+type Contextual struct {
+	// ~Kind eg dashboards
+	Resource string
+	// The specific resource
+	// In grafana, this was historically called "UID", but in k8s, it is the name
+	Name string
+}
+
 // CheckRequest describes the requested access.
 // This is designed bo to play nicely with the kubernetes authorization system:
 // https://github.com/kubernetes/kubernetes/blob/v1.30.3/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go#L28
@@ -29,6 +37,10 @@ type CheckRequest struct {
 
 	// For non-resource requests, this will be the requested URL path
 	Path string
+
+	// Contextuals are additional resource + name that should be checked.
+	// E.g. for dashboards this can be the folder that a it belong to.
+	Contextuals []Contextual
 }
 
 type CheckResponse struct {

--- a/claims/access.go
+++ b/claims/access.go
@@ -2,10 +2,10 @@ package claims
 
 import "context"
 
-// AccessRequest describes the requested access.
+// CheckRequest describes the requested access.
 // This is designed bo to play nicely with the kubernetes authorization system:
 // https://github.com/kubernetes/kubernetes/blob/v1.30.3/staging/src/k8s.io/apiserver/pkg/authorization/authorizer/interfaces.go#L28
-type AccessRequest struct {
+type CheckRequest struct {
 	// The requested access verb.
 	// this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy,
 	// or the lowercased HTTP verb associated with non-API requests (this includes get, put, post, patch, and delete)
@@ -31,15 +31,51 @@ type AccessRequest struct {
 	Path string
 }
 
-type AccessClient interface {
-	// HasAccess checks whether the user can perform the given action for all requests
-	HasAccess(ctx context.Context, id AuthInfo, req AccessRequest) (bool, error)
+type CheckResponse struct {
+	Allowed bool
+}
 
-	// Compile generates a function to check whether the id has access to items matching a request
-	// This is particularly useful when you want to verify access to a list of resources.
-	// Returns nil if there is no access to any matching items
-	Compile(ctx context.Context, id AuthInfo, req AccessRequest) (AccessChecker, error)
+type ListRequest struct {
+	// The requested access verb.
+	// this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy,
+	// or the lowercased HTTP verb associated with non-API requests (this includes get, put, post, patch, and delete)
+	Verb string
+
+	// API group (dashboards.grafana.app)
+	Group string
+
+	// ~Kind eg dashboards
+	Resource string
+
+	// tenant isolation
+	Namespace string
+
+	// Optional subresource
+	Subresource string
+
+	// For non-resource requests, this will be the requested URL path
+	Path string
+}
+
+type ListResponse struct {
+	// If all is set we can access all resources
+	All bool
+	// If all is false this will be popublated with all names we can access
+	Items []string
 }
 
 // Checks access while iterating within a resource
 type AccessChecker func(namespace string, name string) bool
+
+type AccessClient interface {
+	// Check checks whether the identity can perform the given action for all requests
+	Check(ctx context.Context, id AuthInfo, req CheckRequest) (*CheckRequest, error)
+
+	// List returns a list of resource names that can be accessed for given action.
+	List(ctx context.Context, id AuthInfo, req ListRequest) (*ListResponse, error)
+
+	// Compile generates a function to check whether the id has access to items matching a request
+	// This is particularly useful when you want to verify access to a list of resources.
+	// Returns nil if there is no access to any matching items
+	Compile(ctx context.Context, id AuthInfo, req ListRequest) (AccessChecker, error)
+}

--- a/claims/access.go
+++ b/claims/access.go
@@ -57,14 +57,14 @@ type ListRequest struct {
 	// For non-resource requests, this will be the requested URL path
 	Path string
 
+	// tenant isolation
+	Namespace string
+
 	// ~Kind eg dashboards
 	Resource string
 
 	// ContextualResources are additional resources that can be checked to gain access to the resource.
 	ContextualResources []string
-
-	// tenant isolation
-	Namespace string
 }
 
 type ListResponse struct {

--- a/claims/access.go
+++ b/claims/access.go
@@ -22,21 +22,21 @@ type CheckRequest struct {
 	// API group (dashboards.grafana.app)
 	Group string
 
-	// ~Kind eg dashboards
-	Resource string
-
-	// tenant isolation
-	Namespace string
-
-	// The specific resource
-	// In grafana, this was historically called "UID", but in k8s, it is the name
-	Name string
-
 	// Optional subresource
 	Subresource string
 
 	// For non-resource requests, this will be the requested URL path
 	Path string
+
+	// tenant isolation
+	Namespace string
+
+	// ~Kind eg dashboards
+	Resource string
+
+	// The specific resource
+	// In grafana, this was historically called "UID", but in k8s, it is the name
+	Name string
 
 	// Contextuals are additional resource + name that should be checked.
 	// E.g. for dashboards this can be the folder that a it belong to.
@@ -48,25 +48,23 @@ type CheckResponse struct {
 }
 
 type ListRequest struct {
-	// The requested access verb.
-	// this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy,
-	// or the lowercased HTTP verb associated with non-API requests (this includes get, put, post, patch, and delete)
-	Verb string
-
 	// API group (dashboards.grafana.app)
 	Group string
-
-	// ~Kind eg dashboards
-	Resource string
-
-	// tenant isolation
-	Namespace string
 
 	// Optional subresource
 	Subresource string
 
 	// For non-resource requests, this will be the requested URL path
 	Path string
+
+	// ~Kind eg dashboards
+	Resource string
+
+	// ContextualResources are additional resources that can be checked to gain access to the resource.
+	ContextualResources []string
+
+	// tenant isolation
+	Namespace string
 }
 
 type ListResponse struct {
@@ -77,7 +75,7 @@ type ListResponse struct {
 }
 
 // Checks access while iterating within a resource
-type AccessChecker func(namespace string, name string) bool
+type ItemChecker func(namespace, name string, extra ...Contextual) bool
 
 type AccessClient interface {
 	// Check checks whether the identity can perform the given action for all requests
@@ -89,5 +87,5 @@ type AccessClient interface {
 	// Compile generates a function to check whether the id has access to items matching a request
 	// This is particularly useful when you want to verify access to a list of resources.
 	// Returns nil if there is no access to any matching items
-	Compile(ctx context.Context, id AuthInfo, req ListRequest) (AccessChecker, error)
+	Compile(ctx context.Context, id AuthInfo, req ListRequest) (ItemChecker, error)
 }


### PR DESCRIPTION
I want us to get to a state where we have a client interface we can commit to.

As a minimum I think we need something like I have suggested in this pr. There are still some thoughts about some permissions we have that maybe don't fit this standard.

1. First I changed the name of `HasAccess` to `Check` to more closely map it to zanzana. This is an operation that will perform one check for a specific resource.
2. I added `List`. Under the hood this is probably the same as `Compile` without creating a function. I talked a bit with @alexanderzobnin and this is a valid strategy to use if we have few resources when doing filtering.

I added separate Request and Response structures. For list request we don't need to provide a name just the resource type and it is also useful to wrap the response in a structure if we need to add more to it.

There is also a separate function I think we need that I for now call "Capabilities". The idea here would be to query this for a specific resource and get back what actions can be performed on that resource but I have left it out for now because I don't know if it belongs on this interface or not

