### PR TITLE
Tracing: Don't propagate span in context

### DIFF
--- a/authn/grpc_authenticator.go
+++ b/authn/grpc_authenticator.go
@@ -153,19 +153,19 @@ func NewUnsafeGrpcAuthenticator(cfg *GrpcAuthenticatorConfig, opts ...GrpcAuthen
 
 // Authenticate authenticates the incoming request based on the access token and ID token, and returns the context with the caller information.
 func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context, error) {
-	ctx, span := ga.tracer.Start(ctx, "GrpcAuthenticator.Authenticate")
+	spanCtx, span := ga.tracer.Start(ctx, "GrpcAuthenticator.Authenticate")
 	defer span.End()
 
 	authInfo := AuthInfo{}
 
-	md, ok := metadata.FromIncomingContext(ctx)
+	md, ok := metadata.FromIncomingContext(spanCtx)
 	if !ok {
 		span.RecordError(ErrorMissingMetadata)
 		return nil, ErrorMissingMetadata
 	}
 
 	if ga.cfg.accessTokenAuthEnabled {
-		atClaims, err := ga.authenticateService(ctx, md)
+		atClaims, err := ga.authenticateService(spanCtx, md)
 		if err != nil {
 			span.RecordError(err)
 			return nil, err
@@ -178,7 +178,7 @@ func (ga *GrpcAuthenticator) Authenticate(ctx context.Context) (context.Context,
 	}
 
 	if ga.cfg.idTokenAuthEnabled {
-		idClaims, err := ga.authenticateUser(ctx, md)
+		idClaims, err := ga.authenticateUser(spanCtx, md)
 		if err != nil {
 			span.RecordError(err)
 			return nil, err

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -148,16 +148,16 @@ func (gci *GrpcClientInterceptor) StreamClientInterceptor(ctx context.Context, d
 }
 
 func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Context, error) {
-	ctx, span := gci.tracer.Start(ctx, "GrpcClientInterceptor.wrapContext")
+	spanCtx, span := gci.tracer.Start(ctx, "GrpcClientInterceptor.wrapContext")
 	defer span.End()
 
 	md := metadata.Pairs()
 
 	if gci.cfg.accessTokenAuthEnabled {
-		token, err := gci.tokenClient.Exchange(ctx, *gci.cfg.TokenRequest)
+		token, err := gci.tokenClient.Exchange(spanCtx, *gci.cfg.TokenRequest)
 		if err != nil {
 			span.RecordError(err)
-			return ctx, err
+			return spanCtx, err
 		}
 
 		span.SetAttributes(attribute.Bool("with_accesstoken", true))
@@ -166,10 +166,10 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 
 	keys := make([]string, 0, len(gci.metadataExtractors))
 	for _, extract := range gci.metadataExtractors {
-		k, v, err := extract(ctx)
+		k, v, err := extract(spanCtx)
 		if err != nil {
 			span.RecordError(err)
-			return ctx, err
+			return spanCtx, err
 		}
 		keys = append(keys, k)
 		md.Set(k, v...)


### PR DESCRIPTION
Avoid propagating the span in context. It's otherwise considered as parent of the following spans (even if it's ended).

![image](https://github.com/user-attachments/assets/2929b31e-58a3-403c-8046-d1a47afed2f1)