### PR TITLE
Git UI Sync: add type provisioning as a valid type while parsing

### DIFF
--- a/claims/type.go
+++ b/claims/type.go
@@ -61,6 +61,8 @@ func ParseType(str string) (IdentityType, error) {
 		return TypeRenderService, nil
 	case string(TypeAccessPolicy):
 		return TypeAccessPolicy, nil
+	case string(TypeProvisioning):
+		return TypeProvisioning, nil
 	default:
 		return "", ErrInvalidTypedID
 	}


### PR DESCRIPTION
TypeProvisioning is mostly added over here but parsing uses this function and fails to recognize it. This fixes the issue.