### PR TITLE
authn/claims: Fix segfaults in `AuthInfo.GetName()` and `AuthInfo.GetUID()`

### DIFF
--- a/authn/claims.go
+++ b/authn/claims.go
@@ -45,12 +45,18 @@ func (c *AuthInfo) GetGroups() []string {
 
 // Name implements claims.AuthInfo.
 func (c *AuthInfo) GetName() string {
-	return c.IdentityClaims.claims.Rest.getK8sName()
+	if c.IdentityClaims != nil && !c.IdentityClaims.IsNil() {
+		return c.IdentityClaims.claims.Rest.getK8sName()
+	}
+	return ""
 }
 
 // UID implements claims.AuthInfo.
 func (c *AuthInfo) GetUID() string {
-	return c.IdentityClaims.claims.Rest.asTypedUID()
+	if c.IdentityClaims != nil && !c.IdentityClaims.IsNil() {
+		return c.IdentityClaims.claims.Rest.asTypedUID()
+	}
+	return ""
 }
 
 type Identity struct {


### PR DESCRIPTION
These methods currently segfault in case `IdentityClaims` is `nil`. I have added a nil check to avoid the segfaults.

I ran into this when using Unified Storage with the Cloud API Server which only passes an Access Token. The `GetUID()` method is used for creating deletion markers in US. 