### PR TITLE
AuthZ: Add support for Granular Actions - Alternative

### DIFF
--- a/authz/client.go
+++ b/authz/client.go
@@ -332,8 +332,11 @@ func (c *ClientImpl) Check(ctx context.Context, id claims.AuthInfo, req CheckReq
 		}
 
 		action := fmt.Sprintf("%s/%s:%s", req.Group, req.Resource, req.Verb)
+		// Granular action includes the name of the resource
+		granularAction := fmt.Sprintf("%s/%s/%s:%s", req.Group, req.Resource, req.Name, req.Verb)
+
 		for _, p := range id.GetTokenPermissions() {
-			if p == action {
+			if p == action || p == granularAction {
 				return checkResponseAllowed, nil
 			}
 		}
@@ -346,9 +349,12 @@ func (c *ClientImpl) Check(ctx context.Context, id claims.AuthInfo, req CheckReq
 	if c.authCfg.accessTokenAuthEnabled {
 		// Make sure the service is allowed to perform the requested action
 		action := fmt.Sprintf("%s/%s:%s", req.Group, req.Resource, req.Verb)
+		// Granular action includes the name of the resource
+		granularAction := fmt.Sprintf("%s/%s/%s:%s", req.Group, req.Resource, req.Name, req.Verb)
+
 		serviceIsAllowedAction := false
 		for _, p := range id.GetTokenDelegatedPermissions() {
-			if p == action {
+			if p == action || p == granularAction {
 				serviceIsAllowedAction = true
 				break
 			}

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -90,6 +90,20 @@ func TestClient_Check(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "Fail if service has the action on the group",
+			caller: authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+				Claims: jwt.Claims{Subject: "service"},
+				Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", Permissions: []string{"dashboards.grafana.app:list"}},
+			}),
+			req: CheckRequest{
+				Namespace: "stacks-12",
+				Group:     "dashboards.grafana.app",
+				Resource:  "dashboards",
+				Verb:      "list",
+			},
+			want: false,
+		},
+		{
 			name: "Service has a granular action",
 			caller: authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
 				Claims: jwt.Claims{Subject: "service"},

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -105,6 +105,21 @@ func TestClient_Check(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "Service has a granular action on another resource",
+			caller: authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+				Claims: jwt.Claims{Subject: "service"},
+				Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", Permissions: []string{"dashboards.grafana.app/dashboards/otherDashUID:get"}},
+			}),
+			req: CheckRequest{
+				Namespace: "stacks-12",
+				Group:     "dashboards.grafana.app",
+				Resource:  "dashboards",
+				Verb:      "get",
+				Name:      "dashUID",
+			},
+			want: false,
+		},
+		{
 			name: "Service has the action but in the wrong namespace",
 			caller: authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
 				Claims: jwt.Claims{Subject: "service"},
@@ -200,6 +215,28 @@ func TestClient_Check(t *testing.T) {
 			},
 			checkRes: true,
 			want:     true,
+		},
+		{
+			name: "On behalf of, service has granular action on another resource",
+			caller: authn.NewIDTokenAuthInfo(
+				authn.Claims[authn.AccessTokenClaims]{
+					Claims: jwt.Claims{Subject: "service"},
+					Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards.grafana.app/dashboards/otherDashUID:list"}},
+				},
+				&authn.Claims[authn.IDTokenClaims]{
+					Claims: jwt.Claims{Subject: "user:1"},
+					Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
+				},
+			),
+			req: CheckRequest{
+				Namespace: "stacks-12",
+				Group:     "dashboards.grafana.app",
+				Resource:  "dashboards",
+				Verb:      "list",
+				Name:      "dashUID",
+			},
+			checkRes: true,
+			want:     false,
 		},
 	}
 	for _, tt := range tests {

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -90,6 +90,21 @@ func TestClient_Check(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "Service has a granular action",
+			caller: authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
+				Claims: jwt.Claims{Subject: "service"},
+				Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", Permissions: []string{"dashboards.grafana.app/dashboards/dashUID:get"}},
+			}),
+			req: CheckRequest{
+				Namespace: "stacks-12",
+				Group:     "dashboards.grafana.app",
+				Resource:  "dashboards",
+				Verb:      "get",
+				Name:      "dashUID",
+			},
+			want: true,
+		},
+		{
 			name: "Service has the action but in the wrong namespace",
 			caller: authn.NewAccessTokenAuthInfo(authn.Claims[authn.AccessTokenClaims]{
 				Claims: jwt.Claims{Subject: "service"},
@@ -160,6 +175,28 @@ func TestClient_Check(t *testing.T) {
 				Group:     "dashboards.grafana.app",
 				Resource:  "dashboards",
 				Verb:      "list",
+			},
+			checkRes: true,
+			want:     true,
+		},
+		{
+			name: "On behalf of, service has granular action and user has the action",
+			caller: authn.NewIDTokenAuthInfo(
+				authn.Claims[authn.AccessTokenClaims]{
+					Claims: jwt.Claims{Subject: "service"},
+					Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards.grafana.app/dashboards/dashUID:list"}},
+				},
+				&authn.Claims[authn.IDTokenClaims]{
+					Claims: jwt.Claims{Subject: "user:1"},
+					Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
+				},
+			),
+			req: CheckRequest{
+				Namespace: "stacks-12",
+				Group:     "dashboards.grafana.app",
+				Resource:  "dashboards",
+				Verb:      "list",
+				Name:      "dashUID",
 			},
 			checkRes: true,
 			want:     true,


### PR DESCRIPTION
This pull request introduces enhancements to the authorization checks, specifically by adding support for more granular actions. E.g. `dashboard.grafana.app/dashboards/dashUID:get`.