### PR TITLE
Authn: Add function to extract access token used for authentication

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -130,3 +130,7 @@ func (a *AuthInfo) GetIDToken() string {
 	}
 	return ""
 }
+
+func (a *AuthInfo) GetAccessToken() string {
+	return a.at.token
+}

--- a/claims/token.go
+++ b/claims/token.go
@@ -75,4 +75,7 @@ type AuthInfo interface {
 	// GetIDToken returns the singed id token used during authentication.
 	// Will be empty if authencation was performed only using access token.
 	GetIDToken() string
+
+	// GetAccessToken returns the singed access token used during authentication.
+	GetAccessToken() string
 }


### PR DESCRIPTION
If we want to forward the authenticated access token downstream as discussed we need a what to extract it from `claims.AuthInfo`