### PR TITLE
AuthZ: Implement prefix matching

### DIFF
--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -14,6 +14,118 @@ import (
 	"github.com/grafana/authlib/cache"
 )
 
+func TestHasPermissionInToken(t *testing.T) {
+	tests := []struct {
+		name             string
+		tokenPermissions []string
+		group            string
+		resource         string
+		verb             string
+		resourceName     string
+		want             bool
+	}{
+		{
+			name:             "Permission matches group/resource",
+			tokenPermissions: []string{"dashboard.grafana.app/dashboards:list"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "list",
+			want:             true,
+		},
+		{
+			name:             "Permission matches group/resource/name",
+			tokenPermissions: []string{"dashboard.grafana.app/dashboards/dashUID:get"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "get",
+			resourceName:     "dashUID",
+			want:             true,
+		},
+		{
+			name:             "Permission does not match verb",
+			tokenPermissions: []string{"dashboard.grafana.app/dashboards:list"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "get",
+			want:             false,
+		},
+		{
+			name:             "Permission matches wildcard verb",
+			tokenPermissions: []string{"dashboard.grafana.app/dashboards:*"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "get",
+			want:             true,
+		},
+		{
+			name:             "Permission does not match group/resource/name",
+			tokenPermissions: []string{"dashboard.grafana.app/dashboards/otherDashUID:get"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "get",
+			resourceName:     "dashUID",
+			want:             false,
+		},
+		{
+			name:             "Invalid permission missing verb",
+			tokenPermissions: []string{"dashboard.grafana.app/dashboards"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "list",
+			want:             false,
+		},
+		{
+			name:             "Permission on the wrong group",
+			tokenPermissions: []string{"other-group.grafana.app/dashboards:list"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "list",
+			want:             false,
+		},
+		{
+			name:             "Permission on the wrong resource",
+			tokenPermissions: []string{"dashboard.grafana.app/other-resource:list"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "list",
+			want:             false,
+		},
+		{
+			name:             "Permission without group are skipped",
+			tokenPermissions: []string{":get"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "get",
+			resourceName:     "dashUID",
+			want:             false,
+		},
+		{
+			name:             "Group permission work",
+			tokenPermissions: []string{"dashboard.grafana.app:list"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "list",
+			want:             true,
+		},
+		{
+			name:             "Wildcard action works",
+			tokenPermissions: []string{"dashboard.grafana.app/dashboard:*"},
+			group:            "dashboard.grafana.app",
+			resource:         "dashboards",
+			verb:             "get",
+			resourceName:     "dashUID",
+			want:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasPermissionInToken(tt.tokenPermissions, tt.group, tt.resource, tt.verb, tt.resourceName)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestClient_Check(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
```
BenchmarkHasPermissionInToken-12              	 1999384	       611.6 ns/op	     240 B/op	       9 allocs/op
BenchmarkHasPermissionInToken_Prefixs-12      	 2163127	       574.4 ns/op	     192 B/op	       8 allocs/op
```

<details>

```go
func BenchmarkHasPermissionInToken(b *testing.B) {
	tokenPermissions := []string{
		"dashboard.grafana.app/dashboards:list",
		"dashboard.grafana.app/dashboards:get",
		"dashboard.grafana.app/dashboards:create",
		"dashboard.grafana.app/dashboards:delete",
		"dashboard.grafana.app/dashboards:update",
		"dashboard.grafana.app/folders:list",
		"dashboard.grafana.app/folders:get",
		"dashboard.grafana.app/folders:create",
		"dashboard.grafana.app/folders:delete",
		"dashboard.grafana.app/folders:update",
	}

	group := "dashboard.grafana.app"
	resource := "dashboards"
	verb := "get"
	name := "dashUID"

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if !hasPermissionInToken(tokenPermissions, group, resource, verb, name) {
			b.Fail()
		}
	}
}

func BenchmarkHasPermissionInToken_Prefixs(b *testing.B) {
	tokenPermissions := []string{
		"dashboard.grafana.app:get",
	}

	group := "dashboard.grafana.app"
	resource := "dashboards"
	verb := "get"
	name := "dashUID"

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		if !hasPermissionInToken(tokenPermissions, group, resource, verb, name) {
			b.Fail()
		}
	}
}
```

</details>