### PR TITLE
GRPC: Keep existing outgoing headers

### DIFF
--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -155,8 +155,6 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 		md = make(metadata.MD)
 	}
 
-	fmt.Printf("WRAP (before): %+v\n", md)
-
 	if gci.cfg.accessTokenAuthEnabled {
 		token, err := gci.tokenClient.Exchange(spanCtx, *gci.cfg.TokenRequest)
 		if err != nil {
@@ -192,6 +190,5 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 		span.SetAttributes(attribute.String("keys", strings.Join(keys, ",")))
 	}
 
-	fmt.Printf("WRAP (outgoing): %+v\n", md)
 	return metadata.NewOutgoingContext(ctx, md), nil
 }

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -155,6 +155,8 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 		md = make(metadata.MD)
 	}
 
+	fmt.Printf("WRAP (before): %+v\n", md)
+
 	if gci.cfg.accessTokenAuthEnabled {
 		token, err := gci.tokenClient.Exchange(spanCtx, *gci.cfg.TokenRequest)
 		if err != nil {
@@ -190,5 +192,6 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 		span.SetAttributes(attribute.String("keys", strings.Join(keys, ",")))
 	}
 
+	fmt.Printf("WRAP (outgoing): %+v\n", md)
 	return metadata.NewOutgoingContext(ctx, md), nil
 }

--- a/authn/grpc_client_interceptors.go
+++ b/authn/grpc_client_interceptors.go
@@ -149,7 +149,11 @@ func (gci *GrpcClientInterceptor) wrapContext(ctx context.Context) (context.Cont
 	spanCtx, span := gci.tracer.Start(ctx, "GrpcClientInterceptor.wrapContext")
 	defer span.End()
 
-	md := metadata.Pairs()
+	// Keep any existing values
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = make(metadata.MD)
+	}
 
 	if gci.cfg.accessTokenAuthEnabled {
 		token, err := gci.tokenClient.Exchange(spanCtx, *gci.cfg.TokenRequest)


### PR DESCRIPTION
This updates the outgoing GRPC context so it keeps any existing headers.

Required for: https://github.com/grafana/grafana/pull/99199 -- where we try to send request headers in the connection.