### PR TITLE
feat: add org role claim to id token

### DIFF
--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -23,8 +23,8 @@ type IDTokenClaims struct {
 	Username string `json:"username,omitempty"`
 	// Display name of the user (name attribute if it is set, otherwise the login or email)
 	DisplayName string `json:"name,omitempty"`
-	// User's role in Grafana Org
-	OrgRole string `json:"orgRole,omitempty"`
+	// Basic role of entity (Viewer, Editor, Admin)
+	Role string `json:"role,omitempty"`
 }
 
 // Helper for the id

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -23,6 +23,8 @@ type IDTokenClaims struct {
 	Username string `json:"username,omitempty"`
 	// Display name of the user (name attribute if it is set, otherwise the login or email)
 	DisplayName string `json:"name,omitempty"`
+	// User's role in Grafana Org
+	OrgRole string `json:"orgRole,omitempty"`
 }
 
 // Helper for the id


### PR DESCRIPTION
We have had a need come up in addressing a need in the new Direct API Server access project in app platform, which requires being able to determine user's access in cloud auth webhook with a single Authorization header.

The issue is that the authz-service currently is not capable for helping cloud webhook determine what the user's org role is. Until that is the case, we would like to package that within the id token and use our own proprietary format to string together the tokens in the Authorization header.