### PR TITLE
AuthZ: Change constructor to receive a connection

### DIFF
--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -670,7 +670,6 @@ func TestClient_Compile(t *testing.T) {
 func setupAccessClient() (*ClientImpl, *FakeAuthzServiceClient) {
 	fakeClient := &FakeAuthzServiceClient{}
 	return &ClientImpl{
-		authCfg:  &ClientConfig{},
 		clientV1: fakeClient,
 		cache:    cache.NewLocalCache(cache.Config{}),
 		tracer:   noop.NewTracerProvider().Tracer("noopTracer"),


### PR DESCRIPTION
This PR simplifies the AuthZ Client code.
We don't handle setting up the gRPC connection in the lib anymore.