### PR TITLE
Chore: cleanup authenticator and client interceptor

### DIFF
--- a/authn/authenticator.go
+++ b/authn/authenticator.go
@@ -30,17 +30,15 @@ type HTTPTokenProvider struct {
 }
 
 func (p HTTPTokenProvider) AccessToken(_ context.Context) (string, bool) {
-	const header = "X-Access-Token"
 	// Strip the 'Bearer' prefix if it exists.
-	token := strings.TrimPrefix(p.r.Header.Get(header), "Bearer ")
+	token := strings.TrimPrefix(p.r.Header.Get(httpHeaderAccessToken), "Bearer ")
 	return token, len(token) > 0
 
 }
 
 func (p HTTPTokenProvider) IDToken(_ context.Context) (string, bool) {
-	const header = "X-Grafana-Id"
 	// Strip the 'Bearer' prefix if it exists.
-	token := strings.TrimPrefix(p.r.Header.Get(header), "Bearer ")
+	token := strings.TrimPrefix(p.r.Header.Get(httpHeaderIDToken), "Bearer ")
 	return token, len(token) > 0
 }
 
@@ -56,8 +54,7 @@ type GRPCTokenProvider struct {
 }
 
 func (p GRPCTokenProvider) AccessToken(_ context.Context) (string, bool) {
-	const key = "X-Access-Token"
-	values := p.md.Get(key)
+	values := p.md.Get(metadataKeyAccessToken)
 	if len(values) == 0 {
 		return "", false
 	}
@@ -68,8 +65,7 @@ func (p GRPCTokenProvider) AccessToken(_ context.Context) (string, bool) {
 
 func (p GRPCTokenProvider) IDToken(_ context.Context) (string, bool) {
 	// FIXME: we should use the same key as we do over http.
-	const key = "X-Id-Token"
-	values := p.md.Get(key)
+	values := p.md.Get(metadataKeyIDTokenMetadata)
 	if len(values) == 0 {
 		return "", false
 	}

--- a/authn/authenticator.go
+++ b/authn/authenticator.go
@@ -145,28 +145,3 @@ func (a *AccessTokenAuthenticator) Authenticate(ctx context.Context, provider To
 
 	return NewAccessTokenAuthInfo(*claims), nil
 }
-
-var _ Authenticator = (*IDTokenAuthenticator)(nil)
-
-func NewIDTokenAuthenticator(id *IDTokenVerifier) *IDTokenAuthenticator {
-	return &IDTokenAuthenticator{id}
-}
-
-// IDTokenAuthenticator will authenticate using only the id token.
-type IDTokenAuthenticator struct {
-	id *IDTokenVerifier
-}
-
-func (a *IDTokenAuthenticator) Authenticate(ctx context.Context, provider TokenProvider) (types.AuthInfo, error) {
-	token, ok := provider.IDToken(ctx)
-	if !ok {
-		return nil, ErrMissingRequiredToken
-	}
-
-	claims, err := a.id.Verify(ctx, token)
-	if err != nil {
-		return nil, fmt.Errorf("failed to verify access token: %w", err)
-	}
-
-	return NewIDTokenAuthInfo(Claims[AccessTokenClaims]{}, claims), nil
-}

--- a/authn/authenticator_test.go
+++ b/authn/authenticator_test.go
@@ -117,53 +117,6 @@ func TestAccessTokenAuthenticator_Authenticate(t *testing.T) {
 	})
 }
 
-func TestIDTokenAuthenticator_Authenticate(t *testing.T) {
-	authenticator := NewIDTokenAuthenticator(
-		NewUnsafeIDTokenVerifier(VerifierConfig{}),
-	)
-
-	t.Run("should allow request with id token", func(t *testing.T) {
-		provider := fakeTokenProvider{
-			id: signIDToken(t, "user:1", IDTokenClaims{
-				Identifier: "1",
-				Type:       types.TypeUser,
-				Namespace:  "stacks-1",
-			}),
-		}
-
-		info, err := authenticator.Authenticate(context.Background(), provider)
-		require.NoError(t, err)
-		require.Equal(t, "user:1", info.GetUID())
-		require.Equal(t, "stacks-1", info.GetNamespace())
-	})
-
-	t.Run("should ignore access token", func(t *testing.T) {
-		provider := fakeTokenProvider{
-			at: signAtToken(t, "access-policy:1", AccessTokenClaims{Namespace: "*"}),
-			id: signIDToken(t, "user:1", IDTokenClaims{
-				Identifier: "1",
-				Type:       types.TypeUser,
-				Namespace:  "stacks-1",
-			}),
-		}
-
-		info, err := authenticator.Authenticate(context.Background(), provider)
-		require.NoError(t, err)
-		require.Equal(t, "user:1", info.GetUID())
-		require.Equal(t, "stacks-1", info.GetNamespace())
-	})
-
-	t.Run("should reject request if no id token is provided", func(t *testing.T) {
-		provider := fakeTokenProvider{
-			at: signAtToken(t, "access-policy:1", AccessTokenClaims{Namespace: "*"}),
-		}
-
-		info, err := authenticator.Authenticate(context.Background(), provider)
-		require.Error(t, err)
-		require.Nil(t, info)
-	})
-}
-
 var _ TokenProvider = (*fakeTokenProvider)(nil)
 
 type fakeTokenProvider struct {

--- a/authn/const.go
+++ b/authn/const.go
@@ -1,0 +1,9 @@
+package authn
+
+const (
+	metadataKeyAccessToken     = "X-Access-Token"
+	metadataKeyIDTokenMetadata = "X-Id-Token"
+
+	httpHeaderAccessToken = "X-Access-Token"
+	httpHeaderIDToken     = "X-Grafana-Id"
+)

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -199,3 +199,18 @@ func (c *TokenExchangeClient) setCache(ctx context.Context, token string, key st
 
 	return c.cache.Set(ctx, key, []byte(token), time.Until(claims.Expiry.Time())-cacheLeeway)
 }
+
+var _ TokenExchanger = StaticTokenExchanger{}
+
+// NewStaticTokenExchanger Constructs a TokenExchanger that always returned provided token
+func NewStaticTokenExchanger(token string) StaticTokenExchanger {
+	return StaticTokenExchanger{token}
+}
+
+type StaticTokenExchanger struct {
+	token string
+}
+
+func (s StaticTokenExchanger) Exchange(ctx context.Context, r TokenExchangeRequest) (*TokenExchangeResponse, error) {
+	return &TokenExchangeResponse{Token: s.token}, nil
+}


### PR DESCRIPTION
I looked through the usage of client interceptor within grafana.

We no longer use `WithDisableAccessTokenOption` so that was removed. We also never use any of these options:
* `WithMetadataExtractorOption`
* `AccessTokenMetadataKey`
* `IDTokenMetadataKey`

So to clean this component up a bit I changed it so that this one accepts a `TokenExchanger` and move everything else to options. 

Additional changes
* Rename all options to have matching prefix `WithClientInterceptor`
* Added `StaticTokenExchanger` that we can use instead of https://github.com/grafana/grafana/blob/b850c9fa68930bd94d93caae524f2e3dabf79218/pkg/services/authn/grpcutils/inproc_exchanger.go#L14C6-L14C21.
* Removed `IDTokenAuthenticator`, we did not end up using this one
