### PR TITLE
Authz: We don't use "list" for authz so we should not require it for access tokens

### DIFF
--- a/authz/client.go
+++ b/authz/client.go
@@ -131,6 +131,11 @@ func (c *ClientImpl) check(ctx context.Context, id types.AuthInfo, req *types.Ch
 }
 
 func hasPermissionInToken(tokenPermissions []string, group, resource, verb string) bool {
+	// we always map list to get
+	if verb == "list" {
+		verb = "get"
+	}
+
 	for _, p := range tokenPermissions {
 		parts := strings.SplitN(p, ":", 2)
 		if len(parts) != 2 {

--- a/authz/client.go
+++ b/authz/client.go
@@ -134,7 +134,8 @@ func (c *ClientImpl) check(ctx context.Context, id types.AuthInfo, req *types.Ch
 func hasPermissionInToken(tokenPermissions []string, group, resource, verb string) bool {
 	verbs := []string{verb}
 
-	// we always map list to get
+	// we always map list to get for authz
+	// to be backward compatible with access tokens we accept both for now
 	if verb == "list" {
 		verbs = append(verbs, "get")
 	}

--- a/authz/client.go
+++ b/authz/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -131,9 +132,11 @@ func (c *ClientImpl) check(ctx context.Context, id types.AuthInfo, req *types.Ch
 }
 
 func hasPermissionInToken(tokenPermissions []string, group, resource, verb string) bool {
+	verbs := []string{verb}
+
 	// we always map list to get
 	if verb == "list" {
-		verb = "get"
+		verbs = append(verbs, "get")
 	}
 
 	for _, p := range tokenPermissions {
@@ -142,7 +145,7 @@ func hasPermissionInToken(tokenPermissions []string, group, resource, verb strin
 			continue
 		}
 		pVerb := parts[1]
-		if pVerb != "*" && pVerb != verb {
+		if pVerb != "*" && !slices.Contains(verbs, pVerb) {
 			continue
 		}
 

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -26,7 +26,7 @@ func TestHasPermissionInToken(t *testing.T) {
 	}{
 		{
 			name:             "Permission matches group/resource",
-			tokenPermissions: []string{"dashboard.grafana.app/dashboards:list"},
+			tokenPermissions: []string{"dashboard.grafana.app/dashboards:get"},
 			group:            "dashboard.grafana.app",
 			resource:         "dashboards",
 			verb:             "list",
@@ -37,7 +37,7 @@ func TestHasPermissionInToken(t *testing.T) {
 			tokenPermissions: []string{"dashboard.grafana.app/dashboards:list"},
 			group:            "dashboard.grafana.app",
 			resource:         "dashboards",
-			verb:             "get",
+			verb:             "update",
 			want:             false,
 		},
 		{
@@ -58,15 +58,15 @@ func TestHasPermissionInToken(t *testing.T) {
 		},
 		{
 			name:             "Permission on the wrong group",
-			tokenPermissions: []string{"other-group.grafana.app/dashboards:list"},
+			tokenPermissions: []string{"other-group.grafana.app/dashboards:get"},
 			group:            "dashboard.grafana.app",
 			resource:         "dashboards",
-			verb:             "list",
+			verb:             "get",
 			want:             false,
 		},
 		{
 			name:             "Permission on the wrong resource",
-			tokenPermissions: []string{"dashboard.grafana.app/other-resource:list"},
+			tokenPermissions: []string{"dashboard.grafana.app/other-resource:get"},
 			group:            "dashboard.grafana.app",
 			resource:         "dashboards",
 			verb:             "list",
@@ -82,7 +82,7 @@ func TestHasPermissionInToken(t *testing.T) {
 		},
 		{
 			name:             "Group level permission",
-			tokenPermissions: []string{"dashboard.grafana.app:list"},
+			tokenPermissions: []string{"dashboard.grafana.app:get"},
 			group:            "dashboard.grafana.app",
 			resource:         "dashboards",
 			verb:             "list",


### PR DESCRIPTION
We always map verb `list` to `get` for authorization. But here we do required it for access tokens. So if you want to list using access token you also need `group/resource:list`. We should re-map it for them too