### PR TITLE
Keep IsInvalidTokenErr for backward compatibility

### DIFF
--- a/authn/errors.go
+++ b/authn/errors.go
@@ -26,3 +26,8 @@ var (
 func IsUnauthenticatedErr(err error) bool {
 	return errors.Is(err, errInvalidToken)
 }
+
+func IsInvalidTokenErr(err error) bool {
+	// Keeping this for backwards compatibility
+	return errors.Is(err, errInvalidToken)
+}


### PR DESCRIPTION
# What and why

The App Platform team has to get the latest version of authlib in `cloud-apps-platform` monorepo as it contains the [User tole in the ID token claims](https://github.com/grafana/authlib/pull/138) which we need to get to [fix an issue on our side](https://github.com/grafana/grafana-org/issues/365). This update started a never-ending chain of updates, which has its starting point in the change from `IsInvalidTokenErr` to `IsUnauthenticatedErr` ([Slack thread](https://raintank-corp.slack.com/archives/C0764C1GSBH/p1741005163805849)).

This chain of updates is currently kinda blocked by an issue on `grafana/grafana` side described in [this](https://raintank-corp.slack.com/archives/C06JFJ7H3GC/p1741336575757239) and [this](https://raintank-corp.slack.com/archives/C028MCV4R7C/p1741274138003859). 

So, while waiting for that to be resolved, could we re-add the `IsInvalidTokenErr` function so that App Platform is not blocked by this? 