### PR TITLE
AuthZ: Fix split count in `hasPermissionInToken`

### DIFF
--- a/authz/client.go
+++ b/authz/client.go
@@ -154,7 +154,7 @@ func hasPermissionInToken(tokenPermissions []string, group, resource, verb strin
 			continue
 		}
 
-		parts = strings.SplitN(parts[0], "/", 3)
+		parts = strings.SplitN(parts[0], "/", 2)
 		switch len(parts) {
 		case 1:
 			if parts[0] == group {


### PR DESCRIPTION
This PR fixes the split count in `hastPermissionInToken` since we expect at max 2 parts.
This currently has no incidence given the explicit switch case statement was already filtering out `>3` parts results.