### PR TITLE
identity: Add support for custom expiration when exchanging tokens

### DIFF
--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -78,6 +78,8 @@ type TokenExchangeRequest struct {
 	Audiences []string `json:"audiences"`
 	// SubjectToken is the token to exchange in case of a token exchange request.
 	SubjectToken string `json:"subjectToken,omitempty"`
+	// ExpiresIn is the duration, in seconds, before the token expires.
+	ExpiresIn *int `json:"expiresIn,omitempty"`
 }
 
 type TokenExchangeResponse struct {


### PR DESCRIPTION
Part of https://github.com/grafana/identity-access-team/issues/1217.
Relates to https://github.com/grafana/auth/pull/854.

---

This PR introduces support for specifying a custom expiration when exchanging tokens. If not provided, the default will be 10 minutes. 

As a side note, if the signing access policy token defines a `maxExpiration` attribute, a 400-level error will be returned by the API.