### PR TITLE
GetSubject returns the Actor if it is specified

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -82,6 +82,16 @@ func (a *AuthInfo) GetSubject() string {
 	if a.id != nil {
 		return a.id.Subject
 	}
+
+	// Find the subject of the most nested actor
+	currentActor := a.at.Rest.Actor
+	if currentActor != nil {
+		for currentActor.Actor != nil {
+			currentActor = currentActor.Actor
+		}
+		return currentActor.Subject
+	}
+
 	return a.at.Subject
 }
 

--- a/authz/client.go
+++ b/authz/client.go
@@ -187,6 +187,7 @@ func (c *ClientImpl) Check(ctx context.Context, id types.AuthInfo, req types.Che
 		return checkResponseDenied, namespaceMissmatchError(id.GetNamespace(), req.Namespace)
 	}
 
+	span.SetAttributes(attribute.String("subject", id.GetSubject()))
 	span.SetAttributes(attribute.String("namespace", req.Namespace))
 	span.SetAttributes(attribute.String("verb", req.Verb))
 	span.SetAttributes(attribute.String("group", req.Group))
@@ -211,8 +212,6 @@ func (c *ClientImpl) Check(ctx context.Context, id types.AuthInfo, req types.Che
 
 		return types.CheckResponse{Allowed: serviceIsAllowedAction}, nil
 	}
-
-	span.SetAttributes(attribute.String("subject", id.GetSubject()))
 
 	// Only check the service permissions if the access token check is enabled
 	permissions := id.GetTokenDelegatedPermissions()


### PR DESCRIPTION
`AuthInfo.GetSubject` returns the current actor from the `act` claim if that is specified.