### PR TITLE
Return serviceIdentity in the AuthInfo.GetExtra if it's not empty

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -74,7 +74,7 @@ func (a *AuthInfo) GetExtra() map[string][]string {
 
 	result := map[string][]string{}
 	if a.at.Rest.ServiceIdentity != "" {
-		result["serviceIdentity"] = []string{a.at.Rest.ServiceIdentity}
+		result[ServiceIdentityKey] = []string{a.at.Rest.ServiceIdentity}
 	}
 
 	return result

--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -71,7 +71,13 @@ func (a *AuthInfo) GetExtra() map[string][]string {
 		// but this should be removed in the not-to-distant future
 		return map[string][]string{"id-token": {a.id.token}}
 	}
-	return map[string][]string{}
+
+	result := map[string][]string{}
+	if a.at.Rest.ServiceIdentity != "" {
+		result["serviceIdentity"] = []string{a.at.Rest.ServiceIdentity}
+	}
+
+	return result
 }
 
 func (a *AuthInfo) GetAudience() []string {

--- a/authn/const.go
+++ b/authn/const.go
@@ -6,4 +6,6 @@ const (
 
 	httpHeaderAccessToken = "X-Access-Token"
 	httpHeaderIDToken     = "X-Grafana-Id"
+
+	ServiceIdentityKey = "serviceIdentity"
 )


### PR DESCRIPTION
Return the `AccessTokenClaims.Rest.ServiceIdentity` in `AuthInfo.GetExtra()` if the service identity is specified/not empty.