### PR TITLE
AuthN: Maintain service identity during obo requests

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -66,13 +66,14 @@ func (a *AuthInfo) GetGroups() []string {
 }
 
 func (a *AuthInfo) GetExtra() map[string][]string {
+	result := map[string][]string{}
+
 	if a.id != nil {
 		// Currently required for external k8s aggregation
 		// but this should be removed in the not-to-distant future
-		return map[string][]string{"id-token": {a.id.token}}
+		result["id-token"] = []string{a.id.token}
 	}
 
-	result := map[string][]string{}
 	if a.at.Rest.ServiceIdentity != "" {
 		result[ServiceIdentityKey] = []string{a.at.Rest.ServiceIdentity}
 	}


### PR DESCRIPTION
This pull request includes a small refactor to the `GetExtra` method in `authn/auth_info.go`. 
The change populates the service identity in the extra map, even if an id token is involved in the query.
This allows services to check which service is making a call when receiving on-behalf-of user requests. 