### PR TITLE
Expect no namespace in ID token claims for access token OBO flow

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -41,12 +41,15 @@ func getIdInfo(at Claims[AccessTokenClaims]) *Claims[IDTokenClaims] {
 		return nil
 	}
 
-	return &Claims[IDTokenClaims]{
+	claims := &Claims[IDTokenClaims]{
 		Rest: identityActor.IDTokenClaims,
 		Claims: jwt.Claims{
 			Subject: identityActor.Subject,
 		},
 	}
+
+	claims.Rest.Namespace = at.Rest.Namespace
+	return claims
 }
 
 func (a *AuthInfo) GetName() string {

--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -48,6 +48,8 @@ func getIdInfo(at Claims[AccessTokenClaims]) *Claims[IDTokenClaims] {
 		},
 	}
 
+	// Namespace is deliberately not set on the identity actor.
+	// Instead use the namespace from the access token claims.
 	claims.Rest.Namespace = at.Rest.Namespace
 	return claims
 }

--- a/authn/auth_info_test.go
+++ b/authn/auth_info_test.go
@@ -74,6 +74,24 @@ func TestAuthInfo_getIdInfo(t *testing.T) {
 		idInfo := getIdInfo(at)
 		assert.Equal(t, "user-subject", idInfo.Claims.Subject)
 	})
+
+	t.Run("should not use nested namespace", func(t *testing.T) {
+		at := Claims[AccessTokenClaims]{
+			Rest: AccessTokenClaims{
+				Namespace: "at-namespace",
+				Actor: &ActorClaims{
+					Subject: "user-subject",
+					IDTokenClaims: IDTokenClaims{
+						Namespace: "id-namespace",
+						Type:      types.TypeUser,
+					},
+				},
+			},
+		}
+
+		idInfo := getIdInfo(at)
+		assert.Equal(t, "at-namespace", idInfo.Rest.Namespace)
+	})
 }
 
 func TestAuthInfo_GetTokenPermissions(t *testing.T) {

--- a/authn/authenticator.go
+++ b/authn/authenticator.go
@@ -115,7 +115,7 @@ func (a *DefaultAuthenticator) Authenticate(ctx context.Context, provider TokenP
 
 	// verify that access token can operate in the same namespace as id token
 	if !types.NamespaceMatches(atClaims.Rest.Namespace, idClaims.Rest.Namespace) {
-		return nil, errors.New("namespace missmatch")
+		return nil, errors.New("namespace mismatch")
 	}
 
 	return NewIDTokenAuthInfo(*atClaims, idClaims), nil

--- a/authz/client.go
+++ b/authz/client.go
@@ -27,12 +27,12 @@ var (
 )
 
 var (
-	ErrMissingAuthInfo    = errors.New("missing auth info")
-	ErrNamespaceMissmatch = errors.New("namespace missmatch")
+	ErrMissingAuthInfo   = errors.New("missing auth info")
+	ErrNamespaceMismatch = errors.New("namespace mismatch")
 )
 
 func IsUnauthorizedErr(err error) bool {
-	return errors.Is(err, ErrNamespaceMissmatch)
+	return errors.Is(err, ErrNamespaceMismatch)
 }
 
 // ClientImpl will implement the types.AccessClient interface
@@ -184,7 +184,7 @@ func (c *ClientImpl) Check(ctx context.Context, authInfo types.AuthInfo, req typ
 	}
 
 	if !types.NamespaceMatches(authInfo.GetNamespace(), req.Namespace) {
-		return checkResponseDenied, namespaceMissmatchError(authInfo.GetNamespace(), req.Namespace)
+		return checkResponseDenied, namespaceMismatchError(authInfo.GetNamespace(), req.Namespace)
 	}
 
 	span.SetAttributes(attribute.String("subject", authInfo.GetSubject()))
@@ -281,7 +281,7 @@ func (c *ClientImpl) Compile(ctx context.Context, authInfo types.AuthInfo, list 
 	}
 
 	if !types.NamespaceMatches(authInfo.GetNamespace(), list.Namespace) {
-		return nil, namespaceMissmatchError(authInfo.GetNamespace(), list.Namespace)
+		return nil, namespaceMismatchError(authInfo.GetNamespace(), list.Namespace)
 	}
 
 	span.SetAttributes(attribute.String("namespace", list.Namespace))
@@ -469,6 +469,6 @@ func (c *itemChecker) fn(authInfo types.AuthInfo) types.ItemChecker {
 	}
 }
 
-func namespaceMissmatchError(a, b string) error {
-	return fmt.Errorf("%w: got %s but expected %s", ErrNamespaceMissmatch, a, b)
+func namespaceMismatchError(a, b string) error {
+	return fmt.Errorf("%w: got %s but expected %s", ErrNamespaceMismatch, a, b)
 }

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -367,11 +367,11 @@ func TestClient_Check(t *testing.T) {
 					Claims: jwt.Claims{Subject: "service"},
 					Rest: authn.AccessTokenClaims{
 						DelegatedPermissions: []string{"dashboards.grafana.app/dashboards:list"},
+						Namespace:            "stacks-12",
 						Actor: &authn.ActorClaims{
 							Subject: "user:1",
 							IDTokenClaims: authn.IDTokenClaims{
-								Type:      types.TypeUser,
-								Namespace: "stacks-12",
+								Type: types.TypeUser,
 							},
 						},
 					},
@@ -417,13 +417,13 @@ func TestClient_Check(t *testing.T) {
 					Claims: jwt.Claims{Subject: "service"},
 					Rest: authn.AccessTokenClaims{
 						DelegatedPermissions: []string{"dashboards.grafana.app/dashboards:list"},
+						Namespace:            "stacks-12",
 						Actor: &authn.ActorClaims{
 							Subject: "secondService",
 							Actor: &authn.ActorClaims{
 								Subject: "user:1",
 								IDTokenClaims: authn.IDTokenClaims{
-									Type:      types.TypeUser,
-									Namespace: "stacks-12",
+									Type: types.TypeUser,
 								},
 							},
 						},

--- a/types/access.go
+++ b/types/access.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ErrNamespaceMissmatch     = errors.New("namespace missmatch")
+	ErrNamespaceMismatch      = errors.New("namespace mismatch")
 	ErrMissingRequestGroup    = errors.New("missing request group")
 	ErrMissingRequestResource = errors.New("missing request resource")
 	ErrMissingRequestVerb     = errors.New("missing request verb")
@@ -140,6 +140,6 @@ func ValidateListRequest(req ListRequest) error {
 	return nil
 }
 
-func namespaceMissmatchError(a, b string) error {
-	return fmt.Errorf("%w: got %s but expected %s", ErrNamespaceMissmatch, a, b)
+func namespaceMismatchError(a, b string) error {
+	return fmt.Errorf("%w: got %s but expected %s", ErrNamespaceMismatch, a, b)
 }

--- a/types/namespace_test.go
+++ b/types/namespace_test.go
@@ -44,7 +44,7 @@ func TestNamespaceMatches(t *testing.T) {
 			expected:          true,
 		},
 		{
-			desc:              "namespace missmatch",
+			desc:              "namespace mismatch",
 			namespace:         "stacks-1",
 			expectedNamespace: "stacks-2",
 			expected:          false,


### PR DESCRIPTION
Based on these github comments: https://github.com/grafana/auth/pull/884#discussion_r2138168188.

We deliberately do not set the namespace in the identity actor when exchanging tokens through the access token OBO flow. This PR ensures that the root-level namespace is used instead.