### PR TITLE
fix: remove unnecessary span.Event

### DIFF
--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -183,11 +183,10 @@ func (c *TokenExchangeClient) Exchange(ctx context.Context, r TokenExchangeReque
 			}
 
 			res, err = c.client.Do(c.withHeaders(req))
+			addRequestInformationToSpan(span, res, err)
 			// Retry the request if there was a fundamental error, like resolving the host or network error,
 			// or if we get a 429 or a 500s HTTP status code
 			if shouldRetry(res, err) {
-				addRetryInformationToSpan(span, res, err)
-
 				// Consume and close response body after each attempt, so connections can be reused
 				if res != nil {
 					_, _ = io.Copy(io.Discard, res.Body)
@@ -253,17 +252,13 @@ func shouldRetry(res *http.Response, err error) bool {
 	return false
 }
 
-// addRetryInformationToSpan adds an event to the span indicating error and HTTP status code
-func addRetryInformationToSpan(span trace.Span, res *http.Response, err error) {
-	spanAttr := []attribute.KeyValue{}
+// addRequestInformationToSpan adds an event to the span indicating error and HTTP status code
+func addRequestInformationToSpan(span trace.Span, res *http.Response, err error) {
 	if err != nil {
 		span.RecordError(err)
+	} else {
+		span.AddEvent("request", trace.WithAttributes(attribute.Int("status", res.StatusCode)))
 	}
-
-	if res != nil {
-		spanAttr = append(spanAttr, attribute.String("status", res.Status))
-	}
-	span.AddEvent("Failed HTTP request will be retried", trace.WithAttributes(spanAttr...))
 }
 
 func (c *TokenExchangeClient) withHeaders(r *http.Request) *http.Request {


### PR DESCRIPTION
This PR does two things:
- It adds a span event for all external request we make, not only the ones we retry.
- It sets that status as intger so it's easier to search for.
- It removes the unnecessary event once the error was added.