### PR TITLE
[WIP] Make `getIdentityActor` public

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -36,7 +36,7 @@ func NewIDTokenAuthInfo(at Claims[AccessTokenClaims], id *Claims[IDTokenClaims])
 // getIdInfo checks if user info from ID token claims are in the innermost actor of an access token.
 // This can be the case if an ID token is sent in the request to sign an access token.
 func getIdInfo(at Claims[AccessTokenClaims]) *Claims[IDTokenClaims] {
-	identityActor := at.Rest.getIdentityActor()
+	identityActor := at.Rest.GetIdentityActor()
 	if identityActor == nil {
 		return nil
 	}

--- a/authn/verifier_access_token.go
+++ b/authn/verifier_access_token.go
@@ -41,7 +41,7 @@ func (c AccessTokenClaims) getInnermostActor() *ActorClaims {
 	return currentActor
 }
 
-func (c AccessTokenClaims) getIdentityActor() *ActorClaims {
+func (c AccessTokenClaims) GetIdentityActor() *ActorClaims {
 	actor := c.getInnermostActor()
 	if actor == nil {
 		return nil

--- a/authn/verifier_access_token_test.go
+++ b/authn/verifier_access_token_test.go
@@ -44,10 +44,10 @@ func TestAccessToken_getInnermostActor(t *testing.T) {
 	})
 }
 
-func TestAccessToken_getIdentityActor(t *testing.T) {
+func TestAccessToken_GetIdentityActor(t *testing.T) {
 	t.Run("no actor", func(t *testing.T) {
 		claims := AccessTokenClaims{}
-		actor := claims.getIdentityActor()
+		actor := claims.GetIdentityActor()
 		var nilActor *ActorClaims
 		assert.Equal(t, nilActor, actor)
 	})
@@ -61,7 +61,7 @@ func TestAccessToken_getIdentityActor(t *testing.T) {
 			},
 		}
 
-		actor := claims.getIdentityActor()
+		actor := claims.GetIdentityActor()
 		var nilActor *ActorClaims
 		assert.Equal(t, nilActor, actor)
 	})
@@ -78,7 +78,7 @@ func TestAccessToken_getIdentityActor(t *testing.T) {
 			},
 		}
 
-		actor := claims.getIdentityActor()
+		actor := claims.GetIdentityActor()
 		assert.Equal(t, "nested-user-actor", actor.Subject)
 	})
 
@@ -94,7 +94,7 @@ func TestAccessToken_getIdentityActor(t *testing.T) {
 			},
 		}
 
-		actor := claims.getIdentityActor()
+		actor := claims.GetIdentityActor()
 		assert.Equal(t, "nested-user-actor", actor.Subject)
 	})
 }


### PR DESCRIPTION
Part of https://github.com/grafana/identity-access-team/issues/1490.
See https://github.com/grafana/identity-access-team/issues/1490#issuecomment-3045355275 for more context.

---

This PR makes `AccessTokenClaims.getIdentityActor` public to make it easy to determine whether an access token is being used on behalf of a user or another another service.