### PR TITLE
identity: Add helper method for determining if at is on-behalf-of-user

### DIFF
--- a/authn/verifier_access_token.go
+++ b/authn/verifier_access_token.go
@@ -55,6 +55,10 @@ func (c AccessTokenClaims) getIdentityActor() *ActorClaims {
 	return actor
 }
 
+func (c AccessTokenClaims) IsOnBehalfOfUser() bool {
+	return c.getIdentityActor() != nil
+}
+
 func NewAccessTokenVerifier(cfg VerifierConfig, keys KeyRetriever) *AccessTokenVerifier {
 	return &AccessTokenVerifier{
 		v: NewVerifier[AccessTokenClaims](cfg, TokenTypeAccess, keys),

--- a/authn/verifier_access_token_test.go
+++ b/authn/verifier_access_token_test.go
@@ -98,3 +98,46 @@ func TestAccessToken_getIdentityActor(t *testing.T) {
 		assert.Equal(t, "nested-user-actor", actor.Subject)
 	})
 }
+
+func TestAccessToken_IsOnBehalfOfUser(t *testing.T) {
+	t.Run("no actor", func(t *testing.T) {
+		claims := AccessTokenClaims{}
+		assert.False(t, claims.IsOnBehalfOfUser())
+	})
+
+	t.Run("user actor", func(t *testing.T) {
+		claims := AccessTokenClaims{
+			Actor: &ActorClaims{
+				IDTokenClaims: IDTokenClaims{
+					Type: types.TypeUser,
+				},
+			},
+		}
+
+		assert.True(t, claims.IsOnBehalfOfUser())
+	})
+
+	t.Run("service account actor", func(t *testing.T) {
+		claims := AccessTokenClaims{
+			Actor: &ActorClaims{
+				IDTokenClaims: IDTokenClaims{
+					Type: types.TypeServiceAccount,
+				},
+			},
+		}
+
+		assert.True(t, claims.IsOnBehalfOfUser())
+	})
+
+	t.Run("non-user actor", func(t *testing.T) {
+		claims := AccessTokenClaims{
+			Actor: &ActorClaims{
+				IDTokenClaims: IDTokenClaims{
+					Type: types.TypeAccessPolicy,
+				},
+			},
+		}
+
+		assert.False(t, claims.IsOnBehalfOfUser())
+	})
+}


### PR DESCRIPTION
Part of https://github.com/grafana/identity-access-team/issues/1490.
See https://github.com/grafana/identity-access-team/issues/1490#issuecomment-3045355275 for more context.

---

This PR adds a new helper function, `AccessTokenClaims.OnBehalfOfUser`, which lets us easily tell if an access token is being used for a user (and, by extension, if it’s on behalf of a machine).