### PR TITLE
AuthZ: Extract service permission evaluation from the client code

### DIFF
--- a/authz/client.go
+++ b/authz/client.go
@@ -6,8 +6,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"slices"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -133,40 +131,6 @@ func (c *ClientImpl) check(ctx context.Context, authInfo types.AuthInfo, req *ty
 	err = c.cacheCheck(ctx, key, resp.Allowed)
 
 	return resp.Allowed, err
-}
-
-func hasPermissionInToken(tokenPermissions []string, group, resource, verb string) bool {
-	verbs := []string{verb}
-
-	// we always map list to get for authz
-	// to be backward compatible with access tokens we accept both for now
-	if verb == "list" {
-		verbs = append(verbs, "get")
-	}
-
-	for _, p := range tokenPermissions {
-		parts := strings.SplitN(p, ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		pVerb := parts[1]
-		if pVerb != "*" && !slices.Contains(verbs, pVerb) {
-			continue
-		}
-
-		parts = strings.SplitN(parts[0], "/", 2)
-		switch len(parts) {
-		case 1:
-			if parts[0] == group {
-				return true
-			}
-		case 2:
-			if parts[0] == group && parts[1] == resource {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (c *ClientImpl) Check(ctx context.Context, authInfo types.AuthInfo, req types.CheckRequest) (types.CheckResponse, error) {

--- a/authz/service_permissions.go
+++ b/authz/service_permissions.go
@@ -1,6 +1,9 @@
 package authz
 
 import (
+	"slices"
+	"strings"
+
 	"github.com/grafana/authlib/types"
 )
 
@@ -26,4 +29,38 @@ func CheckServicePermissions(authInfo types.AuthInfo, group, resource, verb stri
 	}
 	res.Allowed = hasPermissionInToken(res.Permissions, group, resource, verb)
 	return res
+}
+
+func hasPermissionInToken(tokenPermissions []string, group, resource, verb string) bool {
+	verbs := []string{verb}
+
+	// we always map list to get for authz
+	// to be backward compatible with access tokens we accept both for now
+	if verb == "list" {
+		verbs = append(verbs, "get")
+	}
+
+	for _, p := range tokenPermissions {
+		parts := strings.SplitN(p, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		pVerb := parts[1]
+		if pVerb != "*" && !slices.Contains(verbs, pVerb) {
+			continue
+		}
+
+		parts = strings.SplitN(parts[0], "/", 2)
+		switch len(parts) {
+		case 1:
+			if parts[0] == group {
+				return true
+			}
+		case 2:
+			if parts[0] == group && parts[1] == resource {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
In this PR, I extract the service permission evaluation from the client code to make it reusable to API level Authorizers that only need to check the incoming access token permissions. 