### PR TITLE
AuthN: Add serviceIdentity to actor claims and expose innermost to GetExtra

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -1,6 +1,7 @@
 package authn
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -104,6 +105,17 @@ func (a *AuthInfo) GetExtra() map[string][]string {
 
 	if a.at.Rest.ServiceIdentity != "" {
 		result[ServiceIdentityKey] = []string{a.at.Rest.ServiceIdentity}
+	}
+
+	// This sets the original service identity used in an authenticated request chain.
+	// It will first look for the service identity in the actor claims, and if there's no actor,
+	// it uses the service identity from the subject's claim metadata.
+	// If the actor claims is present but the service identity was not passed or empty, that value is still the one returned.
+	// This is so we preserve the intent of the method, and always return the original identity even when empty.
+	if actor := a.at.Rest.getInnermostActor(); actor != nil {
+		result[InnermostServiceIdentityKey] = []string{actor.ServiceIdentity}
+	} else {
+		result[InnermostServiceIdentityKey] = slices.Clone(result[ServiceIdentityKey])
 	}
 
 	return result

--- a/authn/auth_info_test.go
+++ b/authn/auth_info_test.go
@@ -543,3 +543,86 @@ func TestAuthInfo_GetIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthInfo_GetExtra_InnermostServiceIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		authInfo *AuthInfo
+		expected map[string][]string
+	}{
+		{
+			name: "with an access token without an actor, sets the innermost service identity from its metadata",
+			authInfo: &AuthInfo{
+				at: Claims[AccessTokenClaims]{
+					Rest: AccessTokenClaims{
+						ServiceIdentity: "service-identity",
+					},
+				},
+			},
+			expected: map[string][]string{
+				ServiceIdentityKey:          {"service-identity"},
+				InnermostServiceIdentityKey: {"service-identity"},
+			},
+		},
+		{
+			name: "with an access token with nested actors, sets the innermost service identity from the innermost actor",
+			authInfo: &AuthInfo{
+				at: Claims[AccessTokenClaims]{
+					Rest: AccessTokenClaims{
+						ServiceIdentity: "service-identity",
+						Actor: &ActorClaims{
+							ServiceIdentity: "actor-service-identity",
+							Actor: &ActorClaims{
+								ServiceIdentity: "nested-service-identity",
+								Actor: &ActorClaims{
+									ServiceIdentity: "innermost-service-identity",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string][]string{
+				ServiceIdentityKey:          {"service-identity"},
+				InnermostServiceIdentityKey: {"innermost-service-identity"},
+			},
+		},
+		{
+			name: "with an access token with an actor, preserves the innermost service identity even when empty",
+			authInfo: &AuthInfo{
+				at: Claims[AccessTokenClaims]{
+					Rest: AccessTokenClaims{
+						ServiceIdentity: "service-identity",
+						Actor: &ActorClaims{
+							ServiceIdentity: "",
+						},
+					},
+				},
+			},
+			expected: map[string][]string{
+				ServiceIdentityKey:          {"service-identity"},
+				InnermostServiceIdentityKey: {""},
+			},
+		},
+		{
+			name: "with an ID token only, does not set any service identity",
+			authInfo: &AuthInfo{
+				id: &Claims[IDTokenClaims]{
+					Rest: IDTokenClaims{
+						Type:       "type",
+						Identifier: "identifier",
+					},
+				},
+			},
+			expected: map[string][]string{
+				InnermostServiceIdentityKey: nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.authInfo.GetExtra())
+		})
+	}
+}

--- a/authn/const.go
+++ b/authn/const.go
@@ -7,5 +7,6 @@ const (
 	httpHeaderAccessToken = "X-Access-Token"
 	httpHeaderIDToken     = "X-Grafana-Id"
 
-	ServiceIdentityKey = "serviceIdentity"
+	ServiceIdentityKey          = "serviceIdentity"
+	InnermostServiceIdentityKey = "innermostServiceIdentity"
 )

--- a/authn/verifier_access_token.go
+++ b/authn/verifier_access_token.go
@@ -7,8 +7,9 @@ import (
 )
 
 type ActorClaims struct {
-	Subject string       `json:"sub"`
-	Actor   *ActorClaims `json:"act,omitempty"`
+	Subject         string       `json:"sub"`
+	ServiceIdentity string       `json:"serviceIdentity,omitempty"`
+	Actor           *ActorClaims `json:"act,omitempty"`
 
 	// Embed IDTokenClaims for on behalf of flow.
 	IDTokenClaims

--- a/authn/verifier_access_token_test.go
+++ b/authn/verifier_access_token_test.go
@@ -18,22 +18,27 @@ func TestAccessToken_getInnermostActor(t *testing.T) {
 	t.Run("root-level actor", func(t *testing.T) {
 		claims := AccessTokenClaims{
 			Actor: &ActorClaims{
-				Subject: "subject",
+				Subject:         "subject",
+				ServiceIdentity: "service-identity",
 			},
 		}
 
 		actor := claims.getInnermostActor()
 		assert.Equal(t, "subject", actor.Subject)
+		assert.Equal(t, "service-identity", actor.ServiceIdentity)
 	})
 
 	t.Run("innermost actor", func(t *testing.T) {
 		claims := AccessTokenClaims{
 			Actor: &ActorClaims{
-				Subject: "subject",
+				Subject:         "subject",
+				ServiceIdentity: "service-identity",
 				Actor: &ActorClaims{
-					Subject: "nested-subject",
+					Subject:         "nested-subject",
+					ServiceIdentity: "nested-service-identity",
 					Actor: &ActorClaims{
-						Subject: "innermost-subject",
+						Subject:         "innermost-subject",
+						ServiceIdentity: "innermost-service-identity",
 					},
 				},
 			},
@@ -41,6 +46,7 @@ func TestAccessToken_getInnermostActor(t *testing.T) {
 
 		actor := claims.getInnermostActor()
 		assert.Equal(t, "innermost-subject", actor.Subject)
+		assert.Equal(t, "innermost-service-identity", actor.ServiceIdentity)
 	})
 }
 


### PR DESCRIPTION
This is part of the work to preserve the `serviceIdentity` through chained internally auth-ed requests.

It adds the `ServiceIdentity` into the `ActorClaims`, which will be populated in this PR: https://github.com/grafana/auth/pull/1232

And it also adds a `GetInnermostServiceIdentity` method to easily extract the initial service identity in a request chain.