### PR TITLE
authn: key token exchange cache by stable subject + actor chain

### DIFF
--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -179,6 +179,10 @@ func flattenedActorSubjects(actor *ActorClaims) []string {
 		}
 		actor = actor.Actor
 	}
+	// Canonicalize to originator-first order (deepest actor first).
+	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+		parts[i], parts[j] = parts[j], parts[i]
+	}
 	return parts
 }
 

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -131,9 +131,55 @@ func (r TokenExchangeRequest) hash() string {
 	br.WriteByte('-')
 	sort.Strings(r.Audiences)
 	br.WriteString(strings.Join(r.Audiences, "-"))
-	br.WriteString(r.SubjectToken)
+	br.WriteString(subjectCacheKey(r.SubjectToken))
 
 	return br.String()
+}
+
+type subjectTokenCacheClaims struct {
+	jwt.Claims
+	Actor *ActorClaims `json:"act,omitempty"`
+}
+
+func subjectCacheKey(subjectToken string) string {
+	if subjectToken == "" {
+		return ""
+	}
+
+	parsed, err := jwt.ParseSigned(subjectToken, tokenSignAlgs)
+	if err != nil {
+		// Fall back to old behavior if the token cannot be parsed.
+		return subjectToken
+	}
+
+	var claims subjectTokenCacheClaims
+	if err = parsed.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		// Fall back to old behavior if claims extraction fails.
+		return subjectToken
+	}
+
+	parts := make([]string, 0, 4)
+	if claims.Subject != "" {
+		parts = append(parts, claims.Subject)
+	}
+	parts = append(parts, flattenedActorSubjects(claims.Actor)...)
+	if len(parts) == 0 {
+		// Fall back to old behavior if there is no stable subject signal.
+		return subjectToken
+	}
+
+	return strings.Join(parts, "|")
+}
+
+func flattenedActorSubjects(actor *ActorClaims) []string {
+	parts := make([]string, 0, 3)
+	for actor != nil {
+		if actor.Subject != "" {
+			parts = append(parts, actor.Subject)
+		}
+		actor = actor.Actor
+	}
+	return parts
 }
 
 type tokenExchangeResponse struct {

--- a/authn/token_exchange_test.go
+++ b/authn/token_exchange_test.go
@@ -218,6 +218,96 @@ func Test_TokenExchangeClient_Exchange(t *testing.T) {
 		// This is only testing that the cache is used, so we do not repeat the other cases here.
 	})
 
+	t.Run("should use stable subject plus actor chain for cache key", func(t *testing.T) {
+		var calls int
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			require.Equal(t, r.Header.Get("Authorization"), "Bearer some-token")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		chain := &ActorClaims{
+			Subject: "access-policy:mycap",
+			Actor: &ActorClaims{
+				Subject: "service:gateway",
+				Actor: &ActorClaims{
+					Subject: "user:1",
+				},
+			},
+		}
+
+		token1 := signSubjectToken(t, 10*time.Minute, "access-policy:mycap", chain)
+		token2 := signSubjectToken(t, 11*time.Minute, "access-policy:mycap", chain)
+
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{
+			Namespace:    "*",
+			Audiences:    []string{"some-service"},
+			SubjectToken: token1,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 1, calls)
+
+		// Same stable subject + actor lineage should reuse cache, even if token body changed.
+		res, err = c.Exchange(context.Background(), TokenExchangeRequest{
+			Namespace:    "*",
+			Audiences:    []string{"some-service"},
+			SubjectToken: token2,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("should not reuse cache for different actor chain", func(t *testing.T) {
+		var calls int
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			require.Equal(t, r.Header.Get("Authorization"), "Bearer some-token")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		tokenUser1 := signSubjectToken(t, 10*time.Minute, "access-policy:mycap", &ActorClaims{
+			Subject: "access-policy:mycap",
+			Actor: &ActorClaims{
+				Subject: "service:gateway",
+				Actor: &ActorClaims{
+					Subject: "user:1",
+				},
+			},
+		})
+		tokenUser2 := signSubjectToken(t, 10*time.Minute, "access-policy:mycap", &ActorClaims{
+			Subject: "access-policy:mycap",
+			Actor: &ActorClaims{
+				Subject: "service:gateway",
+				Actor: &ActorClaims{
+					Subject: "user:2",
+				},
+			},
+		})
+
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{
+			Namespace:    "*",
+			Audiences:    []string{"some-service"},
+			SubjectToken: tokenUser1,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 1, calls)
+
+		// Different actor lineage should create a different cache key.
+		res, err = c.Exchange(context.Background(), TokenExchangeRequest{
+			Namespace:    "*",
+			Audiences:    []string{"some-service"},
+			SubjectToken: tokenUser2,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 2, calls)
+	})
+
 	t.Run("should retry requests and return token on successful sign request", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, r.Header.Get("Authorization"), "Bearer some-token")
@@ -349,5 +439,28 @@ func signAccessToken(t *testing.T, expiresIn time.Duration) string {
 		Serialize()
 
 	require.NoError(t, err)
+	return token
+}
+
+func signSubjectToken(t *testing.T, expiresIn time.Duration, subject string, actor *ActorClaims) string {
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.ES256,
+		Key:       testPrivateKey,
+	}, nil)
+	require.NoError(t, err)
+
+	customClaims := AccessTokenClaims{
+		Actor: actor,
+	}
+
+	token, err := jwt.Signed(signer).
+		Claims(&jwt.Claims{
+			Subject: subject,
+			Expiry:  jwt.NewNumericDate(time.Now().Add(expiresIn)),
+		}).
+		Claims(&customClaims).
+		Serialize()
+	require.NoError(t, err)
+
 	return token
 }


### PR DESCRIPTION
## Summary
- change token exchange request hashing to derive cache key from a stable subject identity rather than raw subject token bytes
- reuse existing recursive ActorClaims type and include flattened actor lineage (top-level sub + nested act.sub chain) in the cache key
- preserve backward-compatible fallback to raw subjectToken when parsing or claims extraction fails, or stable fields are absent
- add tests to verify cache reuse across token refresh with same actor chain and cache misses when nested actor changes

## Verification
- go test ./authn -run TokenExchange -count=1