### PR TITLE
AuthN: Add optional Groups to IDTokenClaims

### DIFF
--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -91,7 +91,10 @@ func (a *AuthInfo) GetNamespace() string {
 }
 
 func (a *AuthInfo) GetGroups() []string {
-	return []string{}
+	if a.id != nil {
+		return a.id.Rest.Groups
+	}
+	return nil
 }
 
 func (a *AuthInfo) GetExtra() map[string][]string {

--- a/authn/auth_info.go
+++ b/authn/auth_info.go
@@ -94,6 +94,12 @@ func (a *AuthInfo) GetGroups() []string {
 	if a.id != nil {
 		return a.id.Rest.Groups
 	}
+
+	actor := a.at.Rest.getInnermostActor()
+	if actor != nil {
+		return actor.Groups
+	}
+
 	return nil
 }
 

--- a/authn/auth_info_test.go
+++ b/authn/auth_info_test.go
@@ -544,6 +544,120 @@ func TestAuthInfo_GetIdentifier(t *testing.T) {
 	}
 }
 
+func TestAuthInfo_GetGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		authInfo *AuthInfo
+		expected []string
+	}{
+		{
+			name: "ID token is present with groups, return ID token groups",
+			authInfo: &AuthInfo{
+				id: &Claims[IDTokenClaims]{
+					Rest: IDTokenClaims{
+						Groups: []string{"group1", "group2"},
+					},
+				},
+			},
+			expected: []string{"group1", "group2"},
+		},
+		{
+			name: "ID token is present without groups, return nil",
+			authInfo: &AuthInfo{
+				id: &Claims[IDTokenClaims]{
+					Rest: IDTokenClaims{
+						Type: types.TypeUser,
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "No ID token, no actor, return nil",
+			authInfo: &AuthInfo{
+				at: Claims[AccessTokenClaims]{
+					Claims: jwt.Claims{
+						Subject: "at_subject",
+					},
+				},
+				id: nil,
+			},
+			expected: nil,
+		},
+		{
+			name: "No ID token, actor with groups, return actor groups",
+			authInfo: &AuthInfo{
+				at: Claims[AccessTokenClaims]{
+					Claims: jwt.Claims{
+						Subject: "at_subject",
+					},
+					Rest: AccessTokenClaims{
+						Actor: &ActorClaims{
+							Subject: "actor_subject",
+							IDTokenClaims: IDTokenClaims{
+								Type:   types.TypeUser,
+								Groups: []string{"actor-group"},
+							},
+						},
+					},
+				},
+				id: nil,
+			},
+			expected: []string{"actor-group"},
+		},
+		{
+			name: "No ID token, nested actor level 2, return innermost actor groups",
+			authInfo: &AuthInfo{
+				at: Claims[AccessTokenClaims]{
+					Claims: jwt.Claims{
+						Subject: "at_subject",
+					},
+					Rest: AccessTokenClaims{
+						Actor: &ActorClaims{
+							Subject: "actor1_subject",
+							IDTokenClaims: IDTokenClaims{
+								Groups: []string{"actor1-group"},
+							},
+							Actor: &ActorClaims{
+								Subject: "actor2_subject",
+								IDTokenClaims: IDTokenClaims{
+									Groups: []string{"actor2-group"},
+								},
+							},
+						},
+					},
+				},
+				id: nil,
+			},
+			expected: []string{"actor2-group"},
+		},
+		{
+			name: "No ID token, actor without groups, return nil",
+			authInfo: &AuthInfo{
+				at: Claims[AccessTokenClaims]{
+					Claims: jwt.Claims{
+						Subject: "at_subject",
+					},
+					Rest: AccessTokenClaims{
+						Actor: &ActorClaims{
+							Subject: "actor_subject",
+						},
+					},
+				},
+				id: nil,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.authInfo.GetGroups()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestAuthInfo_GetExtra_InnermostServiceIdentity(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -25,7 +25,8 @@ type IDTokenClaims struct {
 	DisplayName string `json:"name,omitempty"`
 	// Basic role of entity (Viewer, Editor, Admin)
 	Role string `json:"role,omitempty"`
-	// Groups the entity belongs to (from the Identity's group attribute)
+	// Groups the entity belongs to (from the Identity's Group attribute)
+	// Optional, might not be set
 	Groups []string `json:"groups,omitempty"`
 }
 

--- a/authn/verifier_id_token.go
+++ b/authn/verifier_id_token.go
@@ -25,6 +25,8 @@ type IDTokenClaims struct {
 	DisplayName string `json:"name,omitempty"`
 	// Basic role of entity (Viewer, Editor, Admin)
 	Role string `json:"role,omitempty"`
+	// Groups the entity belongs to (from the Identity's group attribute)
+	Groups []string `json:"groups,omitempty"`
 }
 
 // Helper for the id


### PR DESCRIPTION
## Summary
- Adds an optional `Groups []string` field to `IDTokenClaims` in `authn/verifier_id_token.go`, populated from the identity's group attribute.
- Wires `AuthInfo.GetGroups()` to return the ID token groups, falling back to the innermost actor's groups when no ID token is present.
- Adds `TestAuthInfo_GetGroups` covering ID-token, actor, and nested-actor paths.

Relates to https://github.com/grafana/grafana/pull/123249

## Test plan
- [ ] `go test ./authn/...`
- [ ] Verify ID tokens issued with group memberships expose `groups` in the parsed claims and that `AuthInfo.GetGroups()` returns them
- [ ] Verify access tokens with an inner actor (no ID token) surface the innermost actor's groups via `GetGroups()`