### PR TITLE
feat(authn): add scope support to RestrictedDelegatedPermissions

### DIFF
--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -119,10 +119,39 @@ type TokenExchangeRequest struct {
 	SubjectToken string `json:"subjectToken,omitempty"`
 	// [Optional] ExpiresIn is the duration, in seconds, before the token expires.
 	ExpiresIn *int `json:"expiresIn,omitempty"`
-	// [Optional] RestrictedDelegatedPermissions narrows the token's delegated permissions
-	// to the intersection of this list and the CAP's delegated permissions. If omitted,
-	// the full set of CAP delegated permissions is used.
-	RestrictedDelegatedPermissions []string `json:"restrictedDelegatedPermissions,omitempty"`
+	// [Optional] RestrictedDelegatedPermissions narrows the token's delegated permissions.
+	// Each entry specifies an action that should be allowed, optionally scoped to specific
+	// resources. When omitted, the full set of CAP delegated permissions is used.
+	//
+	// Action-only entries restrict at the action level (equivalent to the previous []string behavior):
+	//   {Action: "datasources:read"}
+	//
+	// Scoped entries further restrict to specific resources:
+	//   {Action: "datasources:query", Scope: "datasources:uid:prometheus"}
+	//
+	// The same action may appear multiple times with different scopes to allow access
+	// to multiple specific resources.
+	RestrictedDelegatedPermissions []RestrictedPermission `json:"restrictedDelegatedPermissions,omitempty"`
+}
+
+// RestrictedPermission represents a delegated permission restriction with optional scope.
+// When Scope is empty, the restriction applies to the entire action (all scopes).
+// When Scope is set, only the specified resource scope is allowed for that action.
+type RestrictedPermission struct {
+	// Action is the permission action to restrict (e.g., "datasources:read").
+	Action string `json:"action"`
+	// Scope optionally narrows the restriction to a specific resource scope
+	// (e.g., "datasources:uid:prometheus"). When empty, all scopes are allowed
+	// for this action.
+	Scope string `json:"scope,omitempty"`
+}
+
+// String returns a canonical string representation for hashing and logging.
+func (p RestrictedPermission) String() string {
+	if p.Scope != "" {
+		return p.Action + "|" + p.Scope
+	}
+	return p.Action
 }
 
 type TokenExchangeResponse struct {
@@ -138,10 +167,12 @@ func (r TokenExchangeRequest) hash() string {
 	br.WriteString(subjectCacheKey(r.SubjectToken))
 	if len(r.RestrictedDelegatedPermissions) > 0 {
 		br.WriteByte('-')
-		sorted := make([]string, len(r.RestrictedDelegatedPermissions))
-		copy(sorted, r.RestrictedDelegatedPermissions)
-		sort.Strings(sorted)
-		br.WriteString(strings.Join(sorted, "-"))
+		strs := make([]string, len(r.RestrictedDelegatedPermissions))
+		for i, p := range r.RestrictedDelegatedPermissions {
+			strs[i] = p.String()
+		}
+		sort.Strings(strs)
+		br.WriteString(strings.Join(strs, "-"))
 	}
 
 	return br.String()

--- a/authn/verifier_access_token.go
+++ b/authn/verifier_access_token.go
@@ -25,6 +25,10 @@ type AccessTokenClaims struct {
 	Permissions []string `json:"permissions"`
 	// On-behalf-of user
 	DelegatedPermissions []string `json:"delegatedPermissions"`
+	// RestrictedDelegatedPermissionScopes further restricts delegated permissions
+	// to specific resource scopes. Map of action -> allowed scope patterns.
+	// Populated by the auth API when the caller provides scoped restrictions.
+	RestrictedDelegatedPermissionScopes map[string][]string `json:"restrictedDelegatedPermissionScopes,omitempty"`
 	// Actor is the user/service that is acting on behalf of the subject.
 	Actor *ActorClaims `json:"act,omitempty"`
 	// ServiceIdentity is the name/identity of the service that has been created/signed the access token.


### PR DESCRIPTION
Replace RestrictedDelegatedPermissions []string with []RestrictedPermission, where each entry has an Action (required) and Scope (optional). This enables restricting delegated permissions at the resource scope level, not just the action level.

When Scope is empty, the restriction applies to the entire action (equivalent to the previous []string behavior). When Scope is set, only the specified resource scope is allowed for that action. The same action may appear multiple times with different scopes.

Use case: Grafana Assistant sends data to external LLMs, so admins need to restrict which specific datasources/dashboards the Assistant can access per-org, even if the user has broader RBAC permissions.

This is a breaking change to the type, but the only consumer (Grafana Assistant) has not yet released with the previous []string format. The JSON field name is unchanged, so the wire format is backwards compatible for consumers that don't set scopes.