### PR TITLE
feat: add promqlselector package for zero-dep metric-selector parsing

### DIFF
--- a/promqlselector/LICENSE-PROMETHEUS
+++ b/promqlselector/LICENSE-PROMETHEUS
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/promqlselector/doc.go
+++ b/promqlselector/doc.go
@@ -1,0 +1,39 @@
+// Package promqlselector implements a minimal, zero-dependency parser for
+// PromQL metric selectors.
+//
+// It is a parity extraction of
+// github.com/prometheus/prometheus/promql/parser.ParseMetricSelector pinned
+// to v1.8.2-0.20220315145411-881111fec433 (commit 881111fec433). On valid
+// inputs the matchers returned are identical in order, name, type, and value
+// to the upstream parser. On invalid inputs it rejects the same set of
+// strings (though the error messages are not required to match).
+//
+// Accepted grammar (informal):
+//
+//	selector       := WS? body WS? EOF
+//	body           := metric_name label_matchers?
+//	                | label_matchers
+//	metric_name    := [a-zA-Z_:][a-zA-Z0-9_:]*
+//	label_matchers := '{' WS? ( matcher ( WS? ',' WS? matcher )* ( ',' WS? )? )? '}'
+//	matcher        := label_name WS? op WS? string
+//	label_name     := [a-zA-Z_][a-zA-Z0-9_]*
+//	op             := '=' | '!=' | '=~' | '!~'
+//	string         := double-quoted | single-quoted | backtick-raw
+//
+// Strings support PromQL escape sequences in double and single quotes
+// (\a \b \f \n \r \t \v \\ \' \" \xHH \uHHHH \UHHHHHHHH and three-digit
+// octal). Backtick strings are raw and may not contain a backtick.
+//
+// Line comments starting with '#' are permitted anywhere whitespace is.
+//
+// Explicitly not supported (rejected to match the pinned Prometheus version):
+//
+//   - Quoted label names (PromQL v3 UTF-8 extension), e.g. {"foo"="bar"}
+//   - Range selectors, offsets, @-modifiers
+//   - Binary operators, aggregations, function calls, numeric literals
+//
+// ParseMetricSelector does NOT enforce "at least one non-empty matcher" or
+// reject duplicate __name__ matchers; upstream's equivalent check lives in
+// checkAST which ParseMetricSelector bypasses. This package matches that
+// leniency.
+package promqlselector

--- a/promqlselector/errors.go
+++ b/promqlselector/errors.go
@@ -1,0 +1,26 @@
+package promqlselector
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrParseSelector is the sentinel returned (wrapped) for any parse failure.
+// Callers can match it with errors.Is.
+var ErrParseSelector = errors.New("invalid PromQL metric selector")
+
+// ParseError carries a 1-based line and column offset pointing into the
+// original input string so callers can surface useful diagnostics.
+type ParseError struct {
+	Line int
+	Col  int
+	Msg  string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("%d:%d: parse error: %s", e.Line, e.Col, e.Msg)
+}
+
+func (e *ParseError) Unwrap() error {
+	return ErrParseSelector
+}

--- a/promqlselector/fuzz_test.go
+++ b/promqlselector/fuzz_test.go
@@ -1,0 +1,82 @@
+package promqlselector
+
+import (
+	"errors"
+	"testing"
+)
+
+var fuzzSeeds = []string{
+	"",
+	"foo",
+	"foo:bar",
+	"_foo",
+	"{}",
+	"{a=\"b\"}",
+	"{a!=\"b\"}",
+	"{a=~\"b.*\"}",
+	"{a!~\"b.*\"}",
+	"{a=\"b\",c=\"d\"}",
+	"{a=\"b\",}",
+	"foo{a=\"b\"}",
+	"foo{a=\"b\",c=~\"d.*\"}",
+	"{__name__=\"foo\"}",
+	"{env=\"prod\"}",
+	"{ a = \"b\" , c = \"d\" }",
+	"{a='b'}",
+	"{a=`b`}",
+	"{a=\"\\n\"}",
+	"{a=\"\\xFF\"}",
+	"{a=\"\\u00e9\"}",
+	"{a=\"\\U0001F600\"}",
+	"{a=\"héllo\"}",
+	"{a=\"🦀\"}",
+	"foo # comment",
+	"# leading\nfoo",
+	"{a=\"# not a comment\"}",
+	"{a=~\"foo|bar\"}",
+	"{a=~\"[0-9]+\"}",
+	"{a=~\"(?i)x\"}",
+	"{sum=\"x\"}",
+	"{by=\"x\"}",
+
+	// Expected-reject seeds (exercise error paths without panics).
+	"{env=",
+	"{\"foo\"=\"bar\"}",
+	"{a=}",
+	"{,}",
+	"foo bar",
+	"foo[5m]",
+	"foo offset 1m",
+	"{a=\"b",
+	"{a=`b",
+	"{a=\"\\q\"}",
+	"{a=\"\\x\"}",
+	"{a=\"\\xZZ\"}",
+	"{a=\"\\400\"}",
+	"{a=~\"*\"}",
+	"{foo:bar=\"x\"}",
+	"42",
+	"5m",
+	"foo}",
+	"{a",
+	"}",
+}
+
+func FuzzParseMetricSelector(f *testing.F) {
+	for _, s := range fuzzSeeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		// Invariant: never panic; errors are well-behaved ParseError that
+		// unwraps to ErrParseSelector.
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("panic on input %q: %v", input, r)
+			}
+		}()
+		_, err := ParseMetricSelector(input)
+		if err != nil && !errors.Is(err, ErrParseSelector) {
+			t.Fatalf("error on %q does not wrap ErrParseSelector: %v", input, err)
+		}
+	})
+}

--- a/promqlselector/lexer.go
+++ b/promqlselector/lexer.go
@@ -1,0 +1,193 @@
+package promqlselector
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type tokenType int
+
+const (
+	tkEOF tokenType = iota
+	tkLBrace
+	tkRBrace
+	tkComma
+	tkEqual
+	tkNotEqual
+	tkRegex
+	tkNotRegex
+	tkIdent
+	tkString
+)
+
+func (t tokenType) String() string {
+	switch t {
+	case tkEOF:
+		return "EOF"
+	case tkLBrace:
+		return "'{'"
+	case tkRBrace:
+		return "'}'"
+	case tkComma:
+		return "','"
+	case tkEqual:
+		return "'='"
+	case tkNotEqual:
+		return "'!='"
+	case tkRegex:
+		return "'=~'"
+	case tkNotRegex:
+		return "'!~'"
+	case tkIdent:
+		return "identifier"
+	case tkString:
+		return "string"
+	}
+	return fmt.Sprintf("token(%d)", int(t))
+}
+
+type token struct {
+	typ tokenType
+	// val is empty for punctuation; the identifier text for tkIdent; and the
+	// *quoted* source text (including surrounding quotes) for tkString.
+	val string
+	pos int
+}
+
+// tokenize scans input into a token stream ending in tkEOF.
+func tokenize(input string) ([]token, error) {
+	toks := make([]token, 0, 8)
+	i := 0
+	for i < len(input) {
+		c := input[i]
+		if isSpace(c) {
+			i++
+			continue
+		}
+		if c == '#' {
+			for i < len(input) && input[i] != '\n' {
+				i++
+			}
+			continue
+		}
+		switch {
+		case c == '{':
+			toks = append(toks, token{typ: tkLBrace, pos: i})
+			i++
+		case c == '}':
+			toks = append(toks, token{typ: tkRBrace, pos: i})
+			i++
+		case c == ',':
+			toks = append(toks, token{typ: tkComma, pos: i})
+			i++
+		case c == '=':
+			if i+1 < len(input) && input[i+1] == '~' {
+				toks = append(toks, token{typ: tkRegex, pos: i})
+				i += 2
+			} else {
+				toks = append(toks, token{typ: tkEqual, pos: i})
+				i++
+			}
+		case c == '!':
+			if i+1 < len(input) && input[i+1] == '=' {
+				toks = append(toks, token{typ: tkNotEqual, pos: i})
+				i += 2
+			} else if i+1 < len(input) && input[i+1] == '~' {
+				toks = append(toks, token{typ: tkNotRegex, pos: i})
+				i += 2
+			} else {
+				return nil, perrAt(input, i, "expected '=' or '~' after '!'")
+			}
+		case isIdentStart(c):
+			start := i
+			for i < len(input) && isIdentContinue(input[i]) {
+				i++
+			}
+			toks = append(toks, token{typ: tkIdent, val: input[start:i], pos: start})
+		case c == '"' || c == '\'' || c == '`':
+			start := i
+			end, err := scanString(input, i)
+			if err != nil {
+				return nil, err
+			}
+			toks = append(toks, token{typ: tkString, val: input[start:end], pos: start})
+			i = end
+		default:
+			return nil, perrAt(input, i, fmt.Sprintf("unexpected character %q", c))
+		}
+	}
+	toks = append(toks, token{typ: tkEOF, pos: i})
+	return toks, nil
+}
+
+func scanString(input string, i int) (int, error) {
+	quote := input[i]
+	start := i
+	i++
+	if quote == '`' {
+		for i < len(input) {
+			c := input[i]
+			if c == '`' {
+				return i + 1, nil
+			}
+			r, size := utf8.DecodeRuneInString(input[i:])
+			if r == utf8.RuneError && size == 1 {
+				return 0, perrAt(input, i, "invalid UTF-8 rune")
+			}
+			i += size
+		}
+		return 0, perrAt(input, start, "unterminated raw string")
+	}
+	for i < len(input) {
+		c := input[i]
+		if c == '\\' {
+			if i+1 >= len(input) {
+				return 0, perrAt(input, start, "unterminated quoted string")
+			}
+			i += 2
+			continue
+		}
+		if c == '\n' {
+			return 0, perrAt(input, start, "unterminated quoted string")
+		}
+		if c == quote {
+			return i + 1, nil
+		}
+		r, size := utf8.DecodeRuneInString(input[i:])
+		if r == utf8.RuneError && size == 1 {
+			return 0, perrAt(input, i, "invalid UTF-8 rune")
+		}
+		i += size
+	}
+	return 0, perrAt(input, start, "unterminated quoted string")
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isIdentStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == ':'
+}
+
+func isIdentContinue(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+// perrAt builds a ParseError with a 1-based line:col computed from offset.
+func perrAt(input string, offset int, msg string) *ParseError {
+	line, col := 1, 1
+	end := offset
+	if end > len(input) {
+		end = len(input)
+	}
+	for i := 0; i < end; i++ {
+		if input[i] == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+	}
+	return &ParseError{Line: line, Col: col, Msg: msg}
+}

--- a/promqlselector/matcher.go
+++ b/promqlselector/matcher.go
@@ -1,0 +1,45 @@
+package promqlselector
+
+import "fmt"
+
+// MetricNameLabel is the reserved label name used to represent the metric
+// name in a matcher set. A bare metric name (e.g. `foo`) parses to a single
+// matcher with Name == MetricNameLabel.
+const MetricNameLabel = "__name__"
+
+// MatchType is the operator in a label matcher.
+type MatchType int
+
+const (
+	MatchEqual    MatchType = iota // =
+	MatchNotEqual                  // !=
+	MatchRegexp                    // =~
+	MatchNotRegexp                 // !~
+)
+
+func (t MatchType) String() string {
+	switch t {
+	case MatchEqual:
+		return "="
+	case MatchNotEqual:
+		return "!="
+	case MatchRegexp:
+		return "=~"
+	case MatchNotRegexp:
+		return "!~"
+	}
+	return fmt.Sprintf("MatchType(%d)", int(t))
+}
+
+// Matcher is a label matcher: a label name, an operator, and a value. Regex
+// matchers (MatchRegexp, MatchNotRegexp) have their Value validated as a
+// fully-anchored regexp at parse time but the compiled form is not retained.
+type Matcher struct {
+	Type  MatchType
+	Name  string
+	Value string
+}
+
+func (m Matcher) String() string {
+	return fmt.Sprintf("%s%s%q", m.Name, m.Type, m.Value)
+}

--- a/promqlselector/matcher_test.go
+++ b/promqlselector/matcher_test.go
@@ -1,0 +1,49 @@
+package promqlselector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchType_String(t *testing.T) {
+	cases := []struct {
+		typ  MatchType
+		want string
+	}{
+		{MatchEqual, "="},
+		{MatchNotEqual, "!="},
+		{MatchRegexp, "=~"},
+		{MatchNotRegexp, "!~"},
+		{MatchType(99), "MatchType(99)"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, c.typ.String(), "MatchType(%d).String()", int(c.typ))
+	}
+}
+
+func TestMatcher_String(t *testing.T) {
+	cases := []struct {
+		m    Matcher
+		want string
+	}{
+		{Matcher{MatchEqual, "env", "prod"}, `env="prod"`},
+		{Matcher{MatchNotEqual, "env", "staging"}, `env!="staging"`},
+		{Matcher{MatchRegexp, "path", `/api/.*`}, `path=~"/api/.*"`},
+		{Matcher{MatchNotRegexp, "host", `^x`}, `host!~"^x"`},
+		{Matcher{MatchEqual, MetricNameLabel, "up"}, `__name__="up"`},
+		{Matcher{MatchEqual, "msg", `say "hi"`}, `msg="say \"hi\""`},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, c.m.String())
+	}
+}
+
+func TestParseError_ErrorString(t *testing.T) {
+	_, err := ParseMetricSelector("foo bar")
+	require.Error(t, err)
+	var pe *ParseError
+	require.True(t, errors.As(err, &pe))
+	require.Contains(t, pe.Error(), "1:5: parse error:")
+}

--- a/promqlselector/parser.go
+++ b/promqlselector/parser.go
@@ -1,0 +1,172 @@
+package promqlselector
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// keywordsRejectedAsMetricName lists PromQL keywords that the upstream
+// parser tokenizes as reserved tokens outside braces and therefore refuses
+// to accept as a bare metric name, even though they're valid identifiers.
+// Inside braces these same words are ordinary label names. Lookup is
+// case-insensitive, mirroring upstream's strings.ToLower(word) in lex.go.
+var keywordsRejectedAsMetricName = map[string]struct{}{
+	"atan2":       {},
+	"on":          {},
+	"ignoring":    {},
+	"group_left":  {},
+	"group_right": {},
+	"bool":        {},
+	"inf":         {},
+	"nan":         {},
+}
+
+// ParseMetricSelector parses input as a PromQL instant-vector selector and
+// returns the list of label matchers it contains. A bare metric name is
+// returned as a trailing Matcher with Name == MetricNameLabel.
+func ParseMetricSelector(input string) ([]Matcher, error) {
+	toks, err := tokenize(input)
+	if err != nil {
+		return nil, err
+	}
+	p := &parser{input: input, toks: toks}
+	matchers, err := p.parseSelector()
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().typ != tkEOF {
+		return nil, p.errorAt(p.peek(), fmt.Sprintf("unexpected %s after selector", p.peek().typ))
+	}
+	return matchers, nil
+}
+
+type parser struct {
+	input string
+	toks  []token
+	i     int
+}
+
+func (p *parser) peek() token {
+	return p.toks[p.i]
+}
+
+func (p *parser) consume() token {
+	t := p.toks[p.i]
+	p.i++
+	return t
+}
+
+func (p *parser) errorAt(t token, msg string) *ParseError {
+	return perrAt(p.input, t.pos, msg)
+}
+
+func (p *parser) parseSelector() ([]Matcher, error) {
+	var metricName string
+	switch p.peek().typ {
+	case tkIdent:
+		nameTok := p.consume()
+		if _, bad := keywordsRejectedAsMetricName[strings.ToLower(nameTok.val)]; bad {
+			return nil, p.errorAt(nameTok, fmt.Sprintf("%q is reserved and cannot be a metric name", nameTok.val))
+		}
+		metricName = nameTok.val
+	case tkLBrace:
+		// no metric name
+	case tkEOF:
+		return nil, p.errorAt(p.peek(), "empty selector")
+	default:
+		return nil, p.errorAt(p.peek(), fmt.Sprintf("expected identifier or '{', got %s", p.peek().typ))
+	}
+
+	var matchers []Matcher
+	if p.peek().typ == tkLBrace {
+		var err error
+		matchers, err = p.parseMatcherList()
+		if err != nil {
+			return nil, err
+		}
+	} else if metricName == "" {
+		return nil, p.errorAt(p.peek(), fmt.Sprintf("expected '{', got %s", p.peek().typ))
+	}
+
+	if metricName != "" {
+		matchers = append(matchers, Matcher{
+			Type:  MatchEqual,
+			Name:  MetricNameLabel,
+			Value: metricName,
+		})
+	}
+	return matchers, nil
+}
+
+func (p *parser) parseMatcherList() ([]Matcher, error) {
+	p.consume() // '{'
+	var out []Matcher
+	if p.peek().typ == tkRBrace {
+		p.consume()
+		return out, nil
+	}
+	for {
+		m, err := p.parseMatcher()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+		switch p.peek().typ {
+		case tkComma:
+			p.consume()
+			if p.peek().typ == tkRBrace {
+				p.consume()
+				return out, nil
+			}
+		case tkRBrace:
+			p.consume()
+			return out, nil
+		default:
+			return nil, p.errorAt(p.peek(), fmt.Sprintf("expected ',' or '}', got %s", p.peek().typ))
+		}
+	}
+}
+
+func (p *parser) parseMatcher() (Matcher, error) {
+	nameTok := p.peek()
+	if nameTok.typ != tkIdent {
+		return Matcher{}, p.errorAt(nameTok, fmt.Sprintf("expected label name, got %s", nameTok.typ))
+	}
+	p.consume()
+	if strings.ContainsRune(nameTok.val, ':') {
+		return Matcher{}, p.errorAt(nameTok, "label name must not contain ':'")
+	}
+
+	opTok := p.peek()
+	var mt MatchType
+	switch opTok.typ {
+	case tkEqual:
+		mt = MatchEqual
+	case tkNotEqual:
+		mt = MatchNotEqual
+	case tkRegex:
+		mt = MatchRegexp
+	case tkNotRegex:
+		mt = MatchNotRegexp
+	default:
+		return Matcher{}, p.errorAt(opTok, fmt.Sprintf("expected matcher operator, got %s", opTok.typ))
+	}
+	p.consume()
+
+	strTok := p.peek()
+	if strTok.typ != tkString {
+		return Matcher{}, p.errorAt(strTok, fmt.Sprintf("expected string value, got %s", strTok.typ))
+	}
+	p.consume()
+	val, uerr := Unquote(strTok.val)
+	if uerr != nil {
+		return Matcher{}, p.errorAt(strTok, "invalid string literal")
+	}
+	if mt == MatchRegexp || mt == MatchNotRegexp {
+		if _, rerr := regexp.Compile("^(?:" + val + ")$"); rerr != nil {
+			return Matcher{}, p.errorAt(strTok, fmt.Sprintf("invalid regular expression: %s", rerr))
+		}
+	}
+	return Matcher{Type: mt, Name: nameTok.val, Value: val}, nil
+}

--- a/promqlselector/parser.go
+++ b/promqlselector/parser.go
@@ -85,8 +85,6 @@ func (p *parser) parseSelector() ([]Matcher, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if metricName == "" {
-		return nil, p.errorAt(p.peek(), fmt.Sprintf("expected '{', got %s", p.peek().typ))
 	}
 
 	if metricName != "" {

--- a/promqlselector/parser_prometheus_test.go
+++ b/promqlselector/parser_prometheus_test.go
@@ -1,0 +1,202 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file contains regression test cases ported from
+// github.com/prometheus/prometheus/promql/parser/parse_test.go (pinned
+// version v1.8.2-0.20220315145411-881111fec433 at commit 881111fec433), from
+// the testExpr table (selector-shaped inputs) and TestExtractSelectors. See
+// LICENSE-PROMETHEUS in this directory.
+//
+// Cases are adapted for ParseMetricSelector, which uses the same grammar as
+// upstream's vector_selector rule but skips checkAST — so selectors like
+// {} or foo{__name__="bar"} that upstream's ParseExpr rejects at the AST
+// check layer are accepted here, matching upstream's ParseMetricSelector.
+
+package promqlselector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// promAccept lists selector inputs that upstream ParseMetricSelector accepts,
+// adapted from upstream testExpr entries whose expected is a VectorSelector
+// (or from TestExtractSelectors directly).
+var promAccept = []struct {
+	name  string
+	input string
+	want  []Matcher
+}{
+	// testExpr: pure vector selectors
+	{"foo bare", "foo", []Matcher{{MatchEqual, MetricNameLabel, "foo"}}},
+	{"min bare (keyword allowed as metric name)", "min", []Matcher{{MatchEqual, MetricNameLabel, "min"}}},
+	{"foo:bar", `foo:bar{a="bc"}`, []Matcher{
+		{MatchEqual, "a", "bc"},
+		{MatchEqual, MetricNameLabel, "foo:bar"},
+	}},
+	{"keyword as label name NaN", `foo{NaN='bc'}`, []Matcher{
+		{MatchEqual, "NaN", "bc"},
+		{MatchEqual, MetricNameLabel, "foo"},
+	}},
+	{"right brace inside string", `foo{bar='}'}`, []Matcher{
+		{MatchEqual, "bar", "}"},
+		{MatchEqual, MetricNameLabel, "foo"},
+	}},
+	{"four matchers all ops", `foo{a="b", foo!="bar", test=~"test", bar!~"baz"}`, []Matcher{
+		{MatchEqual, "a", "b"},
+		{MatchNotEqual, "foo", "bar"},
+		{MatchRegexp, "test", "test"},
+		{MatchNotRegexp, "bar", "baz"},
+		{MatchEqual, MetricNameLabel, "foo"},
+	}},
+	{"four matchers trailing comma", `foo{a="b", foo!="bar", test=~"test", bar!~"baz",}`, []Matcher{
+		{MatchEqual, "a", "b"},
+		{MatchNotEqual, "foo", "bar"},
+		{MatchRegexp, "test", "test"},
+		{MatchNotRegexp, "bar", "baz"},
+		{MatchEqual, MetricNameLabel, "foo"},
+	}},
+
+	// Upstream ParseExpr rejects these at checkAST, but ParseMetricSelector
+	// skips checkAST and accepts them (parity-verified).
+	{"empty braces (checkAST-skip)", `{}`, nil},
+	{"single empty match (checkAST-skip)", `{x=""}`, []Matcher{{MatchEqual, "x", ""}}},
+	{"match-all regex (checkAST-skip)", `{x=~".*"}`, []Matcher{{MatchRegexp, "x", ".*"}}},
+	{"match-any-nonempty not-regex (checkAST-skip)", `{x!~".+"}`, []Matcher{{MatchNotRegexp, "x", ".+"}}},
+	{"not-equal (checkAST-skip)", `{x!="a"}`, []Matcher{{MatchNotEqual, "x", "a"}}},
+	{"duplicate __name__ (checkAST-skip)", `foo{__name__="bar"}`, []Matcher{
+		{MatchEqual, MetricNameLabel, "bar"},
+		{MatchEqual, MetricNameLabel, "foo"},
+	}},
+
+	// TestExtractSelectors direct ParseMetricSelector inputs
+	{"extract-selectors foo", `foo`, []Matcher{{MatchEqual, MetricNameLabel, "foo"}}},
+	{"extract-selectors foo with bar=baz", `foo{bar="baz"}`, []Matcher{
+		{MatchEqual, "bar", "baz"},
+		{MatchEqual, MetricNameLabel, "foo"},
+	}},
+}
+
+// promReject lists inputs upstream rejects at the ParseMetricSelector layer
+// (either at lex or at the vector_selector grammar rule — not at checkAST).
+var promReject = []struct {
+	name  string
+	input string
+}{
+	{"lone open brace", `{`},
+	{"lone close brace", `}`},
+	{"metric then open brace EOF", `some{`},
+	{"stray close brace after ident", `some}`},
+	{"value not string", `some_metric{a=b}`},
+	{"colon in label name", `some_metric{a:b="b"}`},
+	{"star op", `foo{a*"b"}`},
+	{"gte op", `foo{a>="b"}`},
+	{"invalid utf8 in value", "some_metric{a=\"\xff\"}"},
+	{"missing operator", `foo{gibberish}`},
+	{"numeric label", `foo{1}`},
+	{"empty matcher", `foo{__name__= =}`},
+	{"lone comma matcher", `foo{,}`},
+	{"double equals op", `foo{__name__ == "bar"}`},
+	{"trailing ident inside braces", `foo{__name__="bar" lol}`},
+	{"matrix selector", "test[5s]"},
+	{"matrix minute", "test[5m]"},
+	{"vector plus offset", `foo offset 5m`},
+	{"vector plus at-modifier", `foo @ 1603774568`},
+	{"vector plus at-modifier Inf (upstream errors)", `foo @ +Inf`},
+}
+
+// promParityGaps lists inputs where upstream ParseMetricSelector's behavior
+// is NOT exercised by upstream's own test suite, but which this package's
+// parity harness surfaced as divergence points when we ran random and
+// generated corpora through both implementations side-by-side. Keep these
+// here as explicit regression anchors: if we ever change lex/parse logic,
+// these are the cases a one-off bug is most likely to re-introduce.
+//
+// Sources of truth:
+//   - Reserved-keyword rejects: upstream grammar rule `metric_identifier`
+//     in generated_parser.y omits ON, IGNORING, GROUP_LEFT, GROUP_RIGHT,
+//     BOOL, ATAN2, and the NUMBER-aliased INF/NAN from the accepted set,
+//     with keyword lookup case-insensitive (strings.ToLower in lex.go).
+//   - Surrogate escapes: upstream lexer lexEscape rejects
+//     0xD800 <= x < 0xE000 at scan time, before reaching the parser.
+//   - Invalid raw UTF-8 in strings: upstream lexString / lexRawString emit
+//     "invalid UTF-8 rune" on utf8.RuneError during scan.
+var promParityGaps = []struct {
+	name  string
+	input string
+}{
+	// Reserved keywords rejected as bare metric names.
+	{"bare metric on", "on"},
+	{"bare metric ON (case-insensitive)", "ON"},
+	{"bare metric atan2", "atan2"},
+	{"bare metric ignoring", "ignoring"},
+	{"bare metric group_left", "group_left"},
+	{"bare metric group_right", "group_right"},
+	{"bare metric bool", "bool"},
+	{"bare metric inf", "inf"},
+	{"bare metric INF (case-insensitive)", "Inf"},
+	{"bare metric nan", "nan"},
+	{"bare metric NaN (case-insensitive)", "NaN"},
+	{"bare metric on with braces", `on{a="b"}`},
+	{"bare metric ignoring with braces", `ignoring{a="b"}`},
+
+	// Surrogate code points in \u and \U escapes (upstream lex rejects; we
+	// ported an explicit surrogate-range check into Unquote to match).
+	{"surrogate u escape low", `{a="\uD800"}`},
+	{"surrogate u escape high", `{a="\uDFFF"}`},
+	{"surrogate U escape", `{a="\U0000D800"}`},
+	{"surrogate in single-quoted", `{a='\uD800'}`},
+
+	// Raw invalid UTF-8 bytes in string bodies (not via \x escape).
+	// Upstream's "\xff" testExpr case is in promReject already; these
+	// add the single-quoted and backtick variants and adjacent byte values
+	// to pin the check.
+	{"raw 0x96 in double-quoted", "{a=\"\x96\"}"},
+	{"raw 0xa7 in single-quoted", "{a='\xa7'}"},
+	{"raw 0xfe in backtick", "{a=`\xfe`}"},
+	{"raw 0x80 midword", "{a=\"fo\x80o\"}"},
+}
+
+func TestParseMetricSelector_UpstreamAccept(t *testing.T) {
+	for _, c := range promAccept {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseMetricSelector(c.input)
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestParseMetricSelector_UpstreamReject(t *testing.T) {
+	for _, c := range promReject {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ParseMetricSelector(c.input)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrParseSelector),
+				"expected error to wrap ErrParseSelector, got %v", err)
+		})
+	}
+}
+
+func TestParseMetricSelector_ParityGaps(t *testing.T) {
+	for _, c := range promParityGaps {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ParseMetricSelector(c.input)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrParseSelector),
+				"expected error to wrap ErrParseSelector, got %v", err)
+		})
+	}
+}

--- a/promqlselector/parser_prometheus_test.go
+++ b/promqlselector/parser_prometheus_test.go
@@ -11,16 +11,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// This file contains regression test cases ported from
+// This file contains regression test cases derived from
 // github.com/prometheus/prometheus/promql/parser/parse_test.go (pinned
-// version v1.8.2-0.20220315145411-881111fec433 at commit 881111fec433), from
-// the testExpr table (selector-shaped inputs) and TestExtractSelectors. See
-// LICENSE-PROMETHEUS in this directory.
+// version v1.8.2-0.20220315145411-881111fec433 at commit 881111fec433). See
+// LICENSE-PROMETHEUS in this directory for the upstream license.
 //
-// Cases are adapted for ParseMetricSelector, which uses the same grammar as
-// upstream's vector_selector rule but skips checkAST — so selectors like
-// {} or foo{__name__="bar"} that upstream's ParseExpr rejects at the AST
-// check layer are accepted here, matching upstream's ParseMetricSelector.
+// Methodology (not a verbatim port):
+//
+//   - promAccept: selector-shaped inputs hand-picked from upstream's
+//     testExpr table — entries whose expected: field was a *VectorSelector
+//     — plus the two ParseMetricSelector inputs from TestExtractSelectors.
+//     PosRange was stripped (we don't track positions), *labels.Matcher
+//     was converted to our value-type Matcher, and the matcher slice was
+//     used directly.
+//
+//   - promReject: selector-shaped fail entries from upstream's testExpr
+//     table — fail-true cases that exercise the selector grammar itself,
+//     not things outside ParseMetricSelector's scope. Error messages are
+//     not asserted; only accept/reject is. Cases that fail upstream solely
+//     because of checkAST (which ParseMetricSelector skips) were moved to
+//     promAccept and labeled (checkAST-skip): {}, {x=""}, {x=~".*"},
+//     {x!~".+"}, {x!="a"}, foo{__name__="bar"}. The parity harness on a
+//     ~13k corpus confirmed those are accepted by upstream's
+//     ParseMetricSelector.
+//
+//   - promParityGaps: divergences this package's parity harness surfaced
+//     when comparing implementations side-by-side — behaviors upstream's
+//     own test suite does not exercise. Source of truth for each set is
+//     noted in-line (grammar rule or lex.go function).
+//
+// The selection is hand-curated rather than mechanically extracted; if
+// upstream adds new selector-shaped test entries, they should be brought
+// over here manually (or via a one-shot extraction script).
 
 package promqlselector
 

--- a/promqlselector/parser_test.go
+++ b/promqlselector/parser_test.go
@@ -1,0 +1,230 @@
+package promqlselector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMetricSelector_Accept(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []Matcher
+	}{
+		// Bare metric names
+		{"bare ident", "foo", []Matcher{{MatchEqual, MetricNameLabel, "foo"}}},
+		{"bare ident underscore", "_foo", []Matcher{{MatchEqual, MetricNameLabel, "_foo"}}},
+		{"bare ident colon", "foo:bar", []Matcher{{MatchEqual, MetricNameLabel, "foo:bar"}}},
+		{"bare ident leading colon", ":foo", []Matcher{{MatchEqual, MetricNameLabel, ":foo"}}},
+		{"bare digits tail", "foo_123", []Matcher{{MatchEqual, MetricNameLabel, "foo_123"}}},
+		{"bare keyword-like sum", "sum", []Matcher{{MatchEqual, MetricNameLabel, "sum"}}},
+		{"bare keyword-like offset", "offset", []Matcher{{MatchEqual, MetricNameLabel, "offset"}}},
+
+		// Empty / metric-only brace combinations
+		{"empty braces", "{}", nil},
+		{"ident with empty braces", "foo{}", []Matcher{{MatchEqual, MetricNameLabel, "foo"}}},
+
+		// Single matcher, all operators
+		{"eq", `{a="b"}`, []Matcher{{MatchEqual, "a", "b"}}},
+		{"neq", `{a!="b"}`, []Matcher{{MatchNotEqual, "a", "b"}}},
+		{"regex", `{a=~"b.*"}`, []Matcher{{MatchRegexp, "a", "b.*"}}},
+		{"not-regex", `{a!~"b.*"}`, []Matcher{{MatchNotRegexp, "a", "b.*"}}},
+
+		// Multiple matchers, trailing comma, whitespace
+		{"two matchers", `{a="b",c="d"}`, []Matcher{
+			{MatchEqual, "a", "b"}, {MatchEqual, "c", "d"},
+		}},
+		{"trailing comma", `{a="b",}`, []Matcher{{MatchEqual, "a", "b"}}},
+		{"trailing comma two", `{a="b",c="d",}`, []Matcher{
+			{MatchEqual, "a", "b"}, {MatchEqual, "c", "d"},
+		}},
+		{"spaces around ops", `{ a = "b" , c = "d" }`, []Matcher{
+			{MatchEqual, "a", "b"}, {MatchEqual, "c", "d"},
+		}},
+		{"newlines in selector", "{\n\ta=\"b\",\n\tc=\"d\"\n}", []Matcher{
+			{MatchEqual, "a", "b"}, {MatchEqual, "c", "d"},
+		}},
+
+		// Metric name + matchers (metric name appended last)
+		{"metric plus match", `foo{a="b"}`, []Matcher{
+			{MatchEqual, "a", "b"},
+			{MatchEqual, MetricNameLabel, "foo"},
+		}},
+		{"metric plus two matches", `foo{a="b",c=~"d.*"}`, []Matcher{
+			{MatchEqual, "a", "b"},
+			{MatchRegexp, "c", "d.*"},
+			{MatchEqual, MetricNameLabel, "foo"},
+		}},
+		{"explicit __name__", `{__name__="foo"}`, []Matcher{
+			{MatchEqual, MetricNameLabel, "foo"},
+		}},
+		{"duplicate __name__", `foo{__name__="bar"}`, []Matcher{
+			{MatchEqual, MetricNameLabel, "bar"},
+			{MatchEqual, MetricNameLabel, "foo"},
+		}},
+		{"empty matcher value accepted", `{a=""}`, []Matcher{{MatchEqual, "a", ""}}},
+
+		// Label-name edge cases (keywords allowed as label names)
+		{"keyword label sum", `{sum="x"}`, []Matcher{{MatchEqual, "sum", "x"}}},
+		{"keyword label by", `{by="x"}`, []Matcher{{MatchEqual, "by", "x"}}},
+		{"keyword label offset", `{offset="x"}`, []Matcher{{MatchEqual, "offset", "x"}}},
+
+		// Non-double-quoted string styles (double-quoted is exercised throughout).
+		{"single-quoted", `{a='b'}`, []Matcher{{MatchEqual, "a", "b"}}},
+		{"backtick raw", "{a=`b\\nc`}", []Matcher{{MatchEqual, "a", `b\nc`}}},
+
+		// Escape sequences
+		{"escape quote", `{a="\""}`, []Matcher{{MatchEqual, "a", `"`}}},
+		{"escape newline", `{a="\n"}`, []Matcher{{MatchEqual, "a", "\n"}}},
+		{"escape tab", `{a="\t"}`, []Matcher{{MatchEqual, "a", "\t"}}},
+		{"escape hex", `{a="\xFF"}`, []Matcher{{MatchEqual, "a", "\xff"}}},
+		{"escape unicode 4", `{a="\u00e9"}`, []Matcher{{MatchEqual, "a", "é"}}},
+		{"escape unicode 8", `{a="\U0001F600"}`, []Matcher{{MatchEqual, "a", "😀"}}},
+		{"escape octal", `{a="\377"}`, []Matcher{{MatchEqual, "a", "\xff"}}},
+		{"escape backslash", `{a="\\"}`, []Matcher{{MatchEqual, "a", `\`}}},
+
+		// UTF-8 in values
+		{"utf8 value", `{a="héllo"}`, []Matcher{{MatchEqual, "a", "héllo"}}},
+		{"emoji value", `{a="🦀"}`, []Matcher{{MatchEqual, "a", "🦀"}}},
+
+		// Comments
+		{"trailing comment", "foo # comment", []Matcher{{MatchEqual, MetricNameLabel, "foo"}}},
+		{"leading comment", "# start\nfoo", []Matcher{{MatchEqual, MetricNameLabel, "foo"}}},
+		{"comment inside braces", "{ # hi\n a=\"b\" # bye\n}", []Matcher{
+			{MatchEqual, "a", "b"},
+		}},
+		{"hash inside string", `{a="# not a comment"}`, []Matcher{
+			{MatchEqual, "a", "# not a comment"},
+		}},
+
+		// Complex regexes
+		{"regex alt", `{a=~"foo|bar"}`, []Matcher{{MatchRegexp, "a", "foo|bar"}}},
+		{"regex empty", `{a=~""}`, []Matcher{{MatchRegexp, "a", ""}}},
+		{"regex case-insensitive", `{a=~"(?i)x"}`, []Matcher{{MatchRegexp, "a", "(?i)x"}}},
+		{"regex char class", `{a=~"[0-9]+"}`, []Matcher{{MatchRegexp, "a", "[0-9]+"}}},
+
+		// Common label-policy shapes used by downstream callers.
+		{"label policy env prod", `{env="prod"}`, []Matcher{{MatchEqual, "env", "prod"}}},
+		{"label policy env dev", `{env="dev"}`, []Matcher{{MatchEqual, "env", "dev"}}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ParseMetricSelector(c.input)
+			require.NoError(t, err)
+			require.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestParseMetricSelector_Reject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		// Malformed syntax
+		{"empty input", ""},
+		{"only whitespace", "   "},
+		{"only comment", "# no selector"},
+		{"unterminated brace open", `{env=`},
+		{"unterminated brace missing close", `{a="b"`},
+		{"lone comma", `{,}`},
+		{"double comma", `{a="b",,c="d"}`},
+		{"missing value", `{a=}`},
+		{"missing op", `{a "b"}`},
+		{"missing label", `{="b"}`},
+		{"trailing garbage after metric", "foo xx"},
+		{"trailing garbage after braces", `{a="b"} xx`},
+		{"stray close brace", `foo}`},
+		{"bare bang", `{a!b}`},
+
+		// Quoted label names (PromQL v3) — must reject
+		{"quoted label name", `{"foo"="bar"}`},
+
+		// Rejected PromQL constructs
+		{"range selector", `foo[5m]`},
+		{"offset", `foo offset 1m`},
+		{"at modifier", `foo @ 0`},
+		{"binary op", `foo + bar`},
+		{"function call", `sum(foo)`},
+		{"number literal", `42`},
+		{"duration", `5m`},
+
+		// Bad strings
+		{"unterminated quoted", `{a="b`},
+		{"unterminated raw", "{a=`b"},
+		{"newline in quoted", "{a=\"b\nc\"}"},
+		{"bad escape", `{a="\q"}`},
+		{"incomplete hex", `{a="\x"}`},
+		{"bad hex", `{a="\xZZ"}`},
+		{"out of range U", `{a="\U12345678"}`},
+		{"bad octal start", `{a="\8"}`},
+		{"octal overflow", `{a="\400"}`},
+
+		// Invalid regex
+		{"invalid regex star", `{a=~"*"}`},
+		{"invalid regex group", `{a=~"(unclosed"}`},
+
+		// Label names with invalid characters
+		{"colon in label", `{foo:bar="x"}`},
+		{"leading colon label", `{:foo="x"}`},
+
+		// Multiple metric names
+		{"double metric", `foo bar`},
+
+		// Reserved keywords rejected as bare metric names (parity with
+		// upstream metric_identifier grammar rule).
+		{"reserved metric on", "on"},
+		{"reserved metric atan2", "atan2"},
+		{"reserved metric ignoring", "ignoring"},
+		{"reserved metric group_left", "group_left"},
+		{"reserved metric group_right", "group_right"},
+		{"reserved metric bool", "bool"},
+		{"reserved metric inf", "inf"},
+		{"reserved metric nan", "nan"},
+		{"reserved metric inf case-insensitive", "Inf"},
+		{"reserved metric on with braces", `on{a="b"}`},
+
+		// Invalid UTF-8 bytes raw (not via escape) in strings.
+		{"invalid utf8 in quoted", "{a=\"\x96\"}"},
+		{"invalid utf8 in single-quoted", "{a='\x96'}"},
+		{"invalid utf8 in backtick", "{a=`\x96`}"},
+
+		// Surrogate escape (parity: upstream rejects at lex time).
+		{"surrogate u escape", `{a="\uD800"}`},
+		{"surrogate U escape", `{a="\U0000D800"}`},
+
+		// Newline in quoted string (upstream: unterminated at lex).
+		{"literal newline in quoted", "{a=\"foo\nbar\"}"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := ParseMetricSelector(c.input)
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrParseSelector),
+				"expected error to wrap ErrParseSelector, got %v", err)
+		})
+	}
+}
+
+func TestParseError_Format(t *testing.T) {
+	_, err := ParseMetricSelector("foo bar")
+	require.Error(t, err)
+	var pe *ParseError
+	require.True(t, errors.As(err, &pe))
+	require.Equal(t, 1, pe.Line)
+	require.Equal(t, 5, pe.Col)
+}
+
+func TestParseError_Multiline(t *testing.T) {
+	// the problem is on line 2, col 1 (the stray `}` just after the newline).
+	_, err := ParseMetricSelector("{a=\"b\"}\n}")
+	require.Error(t, err)
+	var pe *ParseError
+	require.True(t, errors.As(err, &pe))
+	require.Equal(t, 2, pe.Line)
+	require.Equal(t, 1, pe.Col)
+}

--- a/promqlselector/unquote.go
+++ b/promqlselector/unquote.go
@@ -1,0 +1,266 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file was ported verbatim from
+// github.com/prometheus/prometheus/util/strutil/quote.go (pinned version
+// v1.8.2-0.20220315145411-881111fec433). See LICENSE-PROMETHEUS in this
+// directory for the upstream license. The functions here (Unquote,
+// unquoteChar, contains, unhex) were themselves adapted by Prometheus from
+// Go's strconv package; Go's BSD 3-clause notice is preserved below.
+//
+// NOTE: The functions in this file (Unquote, unquoteChar, contains, unhex)
+// have been adapted from the "strconv" package of the Go standard library
+// to work for Prometheus-style strings. Go's special-casing for single
+// quotes was removed and single quoted strings are now treated the same as
+// double-quoted ones.
+//
+// The original copyright notice from the Go project for these parts is
+// reproduced here:
+//
+// ========================================================================
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// ========================================================================
+
+package promqlselector
+
+import (
+	"errors"
+	"unicode/utf8"
+)
+
+// ErrSyntax indicates that a value does not have the right syntax for the target type.
+var ErrSyntax = errors.New("invalid syntax")
+
+// Unquote interprets s as a single-quoted, double-quoted, or backquoted
+// Prometheus query language string literal, returning the string value that s
+// quotes.
+func Unquote(s string) (t string, err error) {
+	n := len(s)
+	if n < 2 {
+		return "", ErrSyntax
+	}
+	quote := s[0]
+	if quote != s[n-1] {
+		return "", ErrSyntax
+	}
+	s = s[1 : n-1]
+
+	if quote == '`' {
+		if contains(s, '`') {
+			return "", ErrSyntax
+		}
+		return s, nil
+	}
+	if quote != '"' && quote != '\'' {
+		return "", ErrSyntax
+	}
+	if contains(s, '\n') {
+		return "", ErrSyntax
+	}
+
+	// Is it trivial?  Avoid allocation.
+	if !contains(s, '\\') && !contains(s, quote) {
+		return s, nil
+	}
+
+	var runeTmp [utf8.UTFMax]byte
+	buf := make([]byte, 0, 3*len(s)/2) // Try to avoid more allocations.
+	for len(s) > 0 {
+		c, multibyte, ss, err := unquoteChar(s, quote)
+		if err != nil {
+			return "", err
+		}
+		s = ss
+		if c < utf8.RuneSelf || !multibyte {
+			buf = append(buf, byte(c))
+		} else {
+			n := utf8.EncodeRune(runeTmp[:], c)
+			buf = append(buf, runeTmp[:n]...)
+		}
+	}
+	return string(buf), nil
+}
+
+// unquoteChar decodes the first character or byte in the escaped string
+// or character literal represented by the string s.
+// It returns four values:
+//
+//  1. value, the decoded Unicode code point or byte value;
+//  2. multibyte, a boolean indicating whether the decoded character requires a multibyte UTF-8 representation;
+//  3. tail, the remainder of the string after the character; and
+//  4. an error that will be nil if the character is syntactically valid.
+//
+// The second argument, quote, specifies the type of literal being parsed
+// and therefore which escaped quote character is permitted.
+// If set to a single quote, it permits the sequence \' and disallows unescaped '.
+// If set to a double quote, it permits \" and disallows unescaped ".
+// If set to zero, it does not permit either escape and allows both quote characters to appear unescaped.
+func unquoteChar(s string, quote byte) (value rune, multibyte bool, tail string, err error) {
+	// easy cases
+	switch c := s[0]; {
+	case c == quote && (quote == '\'' || quote == '"'):
+		err = ErrSyntax
+		return
+	case c >= utf8.RuneSelf:
+		r, size := utf8.DecodeRuneInString(s)
+		return r, true, s[size:], nil
+	case c != '\\':
+		return rune(s[0]), false, s[1:], nil
+	}
+
+	// Hard case: c is backslash.
+	if len(s) <= 1 {
+		err = ErrSyntax
+		return
+	}
+	c := s[1]
+	s = s[2:]
+
+	switch c {
+	case 'a':
+		value = '\a'
+	case 'b':
+		value = '\b'
+	case 'f':
+		value = '\f'
+	case 'n':
+		value = '\n'
+	case 'r':
+		value = '\r'
+	case 't':
+		value = '\t'
+	case 'v':
+		value = '\v'
+	case 'x', 'u', 'U':
+		n := 0
+		switch c {
+		case 'x':
+			n = 2
+		case 'u':
+			n = 4
+		case 'U':
+			n = 8
+		}
+		var v rune
+		if len(s) < n {
+			err = ErrSyntax
+			return
+		}
+		for j := 0; j < n; j++ {
+			x, ok := unhex(s[j])
+			if !ok {
+				err = ErrSyntax
+				return
+			}
+			v = v<<4 | x
+		}
+		s = s[n:]
+		if c == 'x' {
+			// Single-byte string, possibly not UTF-8.
+			value = v
+			break
+		}
+		// Deviation from upstream strutil.Unquote: reject surrogate code
+		// points to match the upstream PromQL lexer, which rejects them at
+		// scan time (promql/parser/lex.go:lexEscape). strutil.Unquote is
+		// called after lex in upstream, so it never saw them.
+		if v > utf8.MaxRune || (v >= 0xD800 && v < 0xE000) {
+			err = ErrSyntax
+			return
+		}
+		value = v
+		multibyte = true
+	case '0', '1', '2', '3', '4', '5', '6', '7':
+		v := rune(c) - '0'
+		if len(s) < 2 {
+			err = ErrSyntax
+			return
+		}
+		for j := 0; j < 2; j++ { // One digit already; two more.
+			x := rune(s[j]) - '0'
+			if x < 0 || x > 7 {
+				err = ErrSyntax
+				return
+			}
+			v = (v << 3) | x
+		}
+		s = s[2:]
+		if v > 255 {
+			err = ErrSyntax
+			return
+		}
+		value = v
+	case '\\':
+		value = '\\'
+	case '\'', '"':
+		if c != quote {
+			err = ErrSyntax
+			return
+		}
+		value = rune(c)
+	default:
+		err = ErrSyntax
+		return
+	}
+	tail = s
+	return
+}
+
+// contains reports whether the string contains the byte c.
+func contains(s string, c byte) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return true
+		}
+	}
+	return false
+}
+
+func unhex(b byte) (v rune, ok bool) {
+	c := rune(b)
+	switch {
+	case '0' <= c && c <= '9':
+		return c - '0', true
+	case 'a' <= c && c <= 'f':
+		return c - 'a' + 10, true
+	case 'A' <= c && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return
+}

--- a/promqlselector/unquote.go
+++ b/promqlselector/unquote.go
@@ -11,9 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// This file was ported verbatim from
+// This file was ported from
 // github.com/prometheus/prometheus/util/strutil/quote.go (pinned version
-// v1.8.2-0.20220315145411-881111fec433). See LICENSE-PROMETHEUS in this
+// v1.8.2-0.20220315145411-881111fec433), with one deviation: unquoteChar
+// rejects surrogate code points (0xD800-0xDFFF) in \u and \U escapes, to
+// match upstream's PromQL lexer (promql/parser/lex.go:lexEscape) which
+// performs that check before strutil.Unquote ever sees the input. The
+// deviation is marked inline at its site. See LICENSE-PROMETHEUS in this
 // directory for the upstream license. The functions here (Unquote,
 // unquoteChar, contains, unhex) were themselves adapted by Prometheus from
 // Go's strconv package; Go's BSD 3-clause notice is preserved below.

--- a/promqlselector/unquote_deviation_test.go
+++ b/promqlselector/unquote_deviation_test.go
@@ -1,0 +1,58 @@
+package promqlselector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestUnquote_RejectsSurrogateEscapes directly exercises the one deviation
+// this package's unquote.go has from upstream strutil.Unquote: \u and \U
+// escapes that decode to surrogate code points (0xD800-0xDFFF) must error.
+// Upstream's PromQL lexer rejects these at scan time before strutil sees
+// them, so upstream's quote_test.go does not cover it. This test pins the
+// deviation so a future refactor of unquote.go cannot silently revert it.
+func TestUnquote_RejectsSurrogateEscapes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"u low surrogate boundary", `"\uD800"`},
+		{"u high surrogate boundary", `"\uDFFF"`},
+		{"u mid surrogate", `"\uDABC"`},
+		{"U low surrogate", `"\U0000D800"`},
+		{"U high surrogate", `"\U0000DFFF"`},
+		{"u surrogate in single-quoted", `'\uD800'`},
+		{"U surrogate in single-quoted", `'\U0000D800'`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := Unquote(c.in)
+			require.Empty(t, out, "Unquote(%#q)", c.in)
+			require.EqualError(t, err, ErrSyntax.Error(), "Unquote(%#q)", c.in)
+		})
+	}
+}
+
+// TestUnquote_AcceptsNonSurrogateBoundaries pins the inverse: code points
+// adjacent to the surrogate range (just below 0xD800 and just above 0xDFFF)
+// must still parse, so the check is exactly bounded.
+func TestUnquote_AcceptsNonSurrogateBoundaries(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"u just below surrogate range", `"퟿"`, "퟿"},
+		{"u just above surrogate range", `""`, ""},
+		{"U just below surrogate range", `"\U0000D7FF"`, "퟿"},
+		{"U just above surrogate range", `"\U0000E000"`, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, err := Unquote(c.in)
+			require.NoError(t, err)
+			require.Equal(t, c.want, out)
+		})
+	}
+}

--- a/promqlselector/unquote_test.go
+++ b/promqlselector/unquote_test.go
@@ -1,0 +1,166 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Ported verbatim from
+// github.com/prometheus/prometheus/util/strutil/quote_test.go (pinned
+// version v1.8.2-0.20220315145411-881111fec433). See LICENSE-PROMETHEUS.
+// The tests were themselves adapted from Go's strconv package; Go's BSD
+// 3-clause notice is preserved below.
+//
+// ========================================================================
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// ========================================================================
+
+package promqlselector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var quotetests = []struct {
+	in    string
+	out   string
+	ascii string
+}{
+	{"\a\b\f\r\n\t\v", `"\a\b\f\r\n\t\v"`, `"\a\b\f\r\n\t\v"`},
+	{"\\", `"\\"`, `"\\"`},
+	{"abc\xffdef", `"abc\xffdef"`, `"abc\xffdef"`},
+	{"\u263a", `"☺"`, `"\u263a"`},
+	{"\U0010ffff", `"\U0010ffff"`, `"\U0010ffff"`},
+	{"\x04", `"\x04"`, `"\x04"`},
+}
+
+var unquotetests = []struct {
+	in  string
+	out string
+}{
+	{`""`, ""},
+	{`"a"`, "a"},
+	{`"abc"`, "abc"},
+	{`"☺"`, "☺"},
+	{`"hello world"`, "hello world"},
+	{`"\xFF"`, "\xFF"},
+	{`"\377"`, "\377"},
+	{`"\u1234"`, "\u1234"},
+	{`"\U00010111"`, "\U00010111"},
+	{`"\U0001011111"`, "\U0001011111"},
+	{`"\a\b\f\n\r\t\v\\\""`, "\a\b\f\n\r\t\v\\\""},
+	{`"'"`, "'"},
+
+	{`''`, ""},
+	{`'a'`, "a"},
+	{`'abc'`, "abc"},
+	{`'☺'`, "☺"},
+	{`'hello world'`, "hello world"},
+	{`'\ahéllo world'`, "\ahéllo world"},
+	{`'\xFF'`, "\xFF"},
+	{`'\377'`, "\377"},
+	{`'\u1234'`, "\u1234"},
+	{`'\U00010111'`, "\U00010111"},
+	{`'\U0001011111'`, "\U0001011111"},
+	{`'\a\b\f\n\r\t\v\\\''`, "\a\b\f\n\r\t\v\\'"},
+	{`'"'`, "\""},
+
+	{"``", ``},
+	{"`a`", `a`},
+	{"`abc`", `abc`},
+	{"`☺`", `☺`},
+	{"`hello world`", `hello world`},
+	{"`\\xFF`", `\xFF`},
+	{"`\\377`", `\377`},
+	{"`\\`", `\`},
+	{"`\n`", "\n"},
+	{"`	`", `	`},
+}
+
+var misquoted = []string{
+	``,
+	`"`,
+	`"a`,
+	`"'`,
+	`b"`,
+	`"\"`,
+	`"\9"`,
+	`"\19"`,
+	`"\129"`,
+	`'\'`,
+	`'\9'`,
+	`'\19'`,
+	`'\129'`,
+	`'\400'`,
+	`"\x1!"`,
+	`"\U12345678"`,
+	`"\z"`,
+	"`",
+	"`xxx",
+	"`\"",
+	`"\'"`,
+	`'\"'`,
+	"\"\n\"",
+	"\"\\n\n\"",
+	"'\n'",
+	"`1`9`",
+	`1231`,
+	`'\xF'`,
+	`""12345"`,
+}
+
+func TestUnquote(t *testing.T) {
+	for _, tt := range unquotetests {
+		out, err := Unquote(tt.in)
+		if err != nil {
+			require.Equal(t, tt.out, out, "Unquote(%#q)", tt.in)
+		}
+	}
+
+	// Run the quote tests too, backward.
+	for _, tt := range quotetests {
+		in, err := Unquote(tt.out)
+		require.Equal(t, tt.in, in, "Unquote(%#q)", tt.out)
+		require.NoError(t, err)
+	}
+
+	for _, s := range misquoted {
+		out, err := Unquote(s)
+		require.Empty(t, out, "Unquote(%#q)", s)
+		require.EqualError(t, err, ErrSyntax.Error(), "Unquote(%#q)", s)
+	}
+}


### PR DESCRIPTION
## Summary

Hand-rolled, zero-external-dep parser for PromQL metric selectors, parity-matched to `github.com/prometheus/prometheus/promql/parser.ParseMetricSelector` at v1.8.2-0.20220315145411-881111fec433. Stdlib-only; no new transitive deps.

## Motivation

A downstream Grafana service depends on `github.com/prometheus/prometheus` solely to validate PromQL label-policy selectors at write time, via a single `ParseMetricSelector` call that discards its matcher output and only checks the returned error. That one call pulls 223 modules exclusively into the consumer's `go.mod` (~25% of its transitive graph). The grammar is small and stable, so a parity extraction is a much cheaper way to keep validation correctness without the dep weight. Publishing here so other Grafana services with the same use case (e.g. teamlbac, pyroscope datasource) can reuse it without each maintaining their own copy.

## What's here

- `promqlselector/` — flat leaf package, stdlib imports only:
  - `parser.go` — recursive-descent parser (~170 LoC)
  - `lexer.go` — hand-rolled scanner with two-state token stream (~190 LoC)
  - `unquote.go` — ported from `prometheus/util/strutil/quote.go` (Apache 2.0 + Go BSD attribution preserved), with one deviation marked inline at its site: an explicit surrogate-range reject for `\u`/`\U` escapes (0xD800-0xDFFF). Upstream's PromQL lexer catches surrogates at scan time before `strutil.Unquote` ever sees them, so the function as-published doesn't have the check; we need it because we use Unquote directly.
  - `matcher.go`, `errors.go`, `doc.go` — types and package doc

## Parity verification

An out-of-tree harness compared this parser to upstream on a 12,968-case corpus (generated permutations across operators × quote styles × matcher counts × trailing commas, random byte-level mutations, upstream `testExpr` selector-shaped inputs, and common label-policy shapes). Zero divergences. Three classes of divergence were caught and fixed during development:

1. Reserved keywords as bare metric names (`on`, `atan2`, `inf`, `nan`, etc.) — upstream's grammar rule `metric_identifier` rejects them; we now do too. Case-insensitive.
2. Surrogate code points in `\u`/`\U` escapes — upstream's lexer rejects 0xD800-0xDFFF at scan time; ported Unquote did not. Added the check (see `unquote.go` deviation note).
3. Raw invalid UTF-8 bytes in string bodies (not via `\x`) — upstream's `lexString`/`lexRawString` reject `utf8.RuneError`; our scanner now does the same.

## Tests

- `parser_test.go` — ~60 accept + ~50 reject hand-crafted cases covering every grammar feature.
- `parser_prometheus_test.go` — three hand-curated sections derived from upstream (not mechanically extracted — see file header for methodology):
  - 17 accept cases hand-picked from upstream `testExpr` (entries whose `expected:` was a `*VectorSelector`) and the 2 inputs in `TestExtractSelectors`. `PosRange` stripped, `*labels.Matcher` converted to our value type.
  - 20 reject cases — selector-grammar `fail: true` entries from `testExpr`. Six entries that upstream rejects only via `checkAST` (which `ParseMetricSelector` skips) were moved to the accept section and tagged `(checkAST-skip)`; the parity harness confirmed that reclassification.
  - 21 parity-gap cases — NOT from upstream's tests. They pin divergences our parity harness caught that upstream's own suite doesn't exercise (reserved-keyword bare metric names, surrogate escapes, raw invalid UTF-8). Each case is annotated with upstream's source of truth (grammar rule or `lex.go` function).
- `unquote_test.go` — full upstream `quote_test.go` test vectors (verbatim port).
- `unquote_deviation_test.go` — 7 surrogate-reject cases + 4 boundary-accept cases at U+D7FF / U+E000 to pin the surrogate-range bounds directly in unquote-level unit tests (upstream's tests don't cover this since their lexer catches surrogates earlier).
- `matcher_test.go` — pins the `MatchType.String`, `Matcher.String`, and `ParseError.Error` diagnostic methods (caught via coverage report).
- `fuzz_test.go` — `FuzzParseMetricSelector` with 50 seeds; verified 1.3M+ executions with no panics and all errors wrap `ErrParseSelector`.

Combined coverage (parity harness + unit tests) is **99.3% of statements**; the remaining 0.7% is two defensive guards (a `tokenType.String` default fallthrough and a `perrAt` offset clamp) that no reachable input can trigger.

## Benchmarks

Comparison on representative inputs (`go test -bench=. -benchmem`, AMD Ryzen AI 7 PRO 360):

| case | this PR ns/op | upstream ns/op | speedup | this PR allocs | upstream allocs |
|------|--------------:|---------------:|--------:|---------------:|----------------:|
| bare_metric | 107 | 228 | 2.1x | 2 | 3 |
| simple_eq `{env="prod"}` | 127 | 477 | 3.7x | 2 | 5 |
| simple_neq | 138 | 419 | 3.0x | 2 | 5 |
| simple_regex `{env=~"prod\|staging"}` | 4531 | 4822 | 1.1x | 66 | 83 |
| two_matchers | 364 | 687 | 1.9x | 4 | 9 |
| four_matchers_all_ops | 4682 | 6106 | 1.3x | 79 | 106 |
| metric_plus_two | 576 | 911 | 1.6x | 5 | 11 |
| deep_regex | 17966 | 27234 | 1.5x | 256 | 322 |
| long_value (500-char) | 1547 | 2084 | 1.3x | 2 | 5 |
| many_matchers (16) | 2311 | 3750 | 1.6x | 9 | 56 |
| utf8_value | 149 | 489 | 3.3x | 2 | 5 |
| escape_value | 282 | 603 | 2.1x | 4 | 7 |
| err_unterminated | 220 | 1343 | 6.1x | 3 | 7 |
| err_quoted_label | 195 | 2313 | 11.9x | 3 | 16 |

Happy-path selectors are 2-4x faster with substantially fewer allocations (lexer keeps tokens as stack values rather than channel-fed heap items). Regex-heavy cases narrow to ~1.1-1.5x — both implementations bottleneck on `regexp.Compile`. Error paths are 6-12x faster because we bail at the first lex/parse failure instead of running through the yacc state machine.

## Test plan

- [x] CI passes (`go test ./promqlselector/...`)
- [x] `go test -fuzz=FuzzParseMetricSelector -fuzztime=1m ./promqlselector/` runs locally with no panics
- [x] Manual verification of the `parser_prometheus_test.go` hand-curated cases against upstream test source (links in file header)
- [ ] Downstream consumer migration PR opens against this package once it's tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)