### PR TITLE
authz: Add Subresource to FilterAuthorized's BatchCheckItem

### DIFF
--- a/authz/filter.go
+++ b/authz/filter.go
@@ -16,12 +16,13 @@ import (
 
 // BatchCheckItem represents an item that needs batch authorization.
 type BatchCheckItem struct {
-	Name      string
-	Folder    string
-	Group     string
-	Resource  string
-	Verb      string
-	Namespace string
+	Name        string
+	Folder      string
+	Group       string
+	Resource    string
+	Subresource string
+	Verb        string
+	Namespace   string
 	// FreshnessTimestamp is when the resource was last modified.
 	// If provided, the server will skip cache for this item if the cached result
 	// is older than this timestamp.
@@ -122,6 +123,7 @@ func FilterAuthorized[T any](
 				Verb:               info.Verb,
 				Group:              info.Group,
 				Resource:           info.Resource,
+				Subresource:        info.Subresource,
 				Name:               info.Name,
 				Folder:             info.Folder,
 				FreshnessTimestamp: info.FreshnessTimestamp,

--- a/authz/filter_test.go
+++ b/authz/filter_test.go
@@ -204,3 +204,48 @@ func TestFilterAuthorized_NamespaceSwitch(t *testing.T) {
 	assert.Len(t, fakeClient.batchCheckReqs[2].Checks, 1)
 	assert.Equal(t, "ns3", fakeClient.batchCheckReqs[2].Namespace)
 }
+
+func TestFilterAuthorized_ForwardsSubresource(t *testing.T) {
+	items := []testItem{{name: "item-0", folder: "folder1", namespace: "ns1"}}
+
+	client, fakeClient := setupAccessClient()
+	fakeClient.checkRes = &authzv1.CheckResponse{Allowed: true}
+
+	// IDTokenAuthInfo routes the check through authz (rather than the service path),
+	// so it reaches the proto request we record.
+	authInfo := authn.NewIDTokenAuthInfo(
+		authn.Claims[authn.AccessTokenClaims]{
+			Claims: jwt.Claims{Subject: "access-policy"},
+			Rest: authn.AccessTokenClaims{
+				Namespace:            "*",
+				DelegatedPermissions: []string{"test.grafana.app/items:get"},
+			},
+		},
+		&authn.Claims[authn.IDTokenClaims]{
+			Claims: jwt.Claims{Subject: "user:1"},
+			Rest:   authn.IDTokenClaims{Namespace: "*"},
+		},
+	)
+	ctx := types.WithAuthInfo(context.Background(), authInfo)
+
+	extract := func(item testItem) BatchCheckItem {
+		return BatchCheckItem{
+			Name:        item.name,
+			Folder:      item.folder,
+			Verb:        "get",
+			Group:       "test.grafana.app",
+			Resource:    "items",
+			Subresource: "status",
+			Namespace:   item.namespace,
+		}
+	}
+
+	for _, err := range FilterAuthorized(ctx, client, toSeq(items), extract) {
+		require.NoError(t, err)
+	}
+
+	// The subresource set on the convenience item must reach the underlying check.
+	require.Len(t, fakeClient.batchCheckReqs, 1)
+	require.Len(t, fakeClient.batchCheckReqs[0].Checks, 1)
+	assert.Equal(t, "status", fakeClient.batchCheckReqs[0].Checks[0].Subresource)
+}


### PR DESCRIPTION
## What

Adds a `Subresource` field to the `authz.BatchCheckItem` convenience type used by `FilterAuthorized`, and forwards it into the underlying `types.BatchCheckItem`.

## Why

`FilterAuthorized` is the ergonomic way to batch-authorize a stream of items, but its convenience `BatchCheckItem` had no `Subresource` field — so any caller needing to authorize a subresource had to bypass `FilterAuthorized` entirely and call `BatchCheck` directly, reimplementing batching, correlation-ID mapping, and tracing by hand.

A concrete case: Grafana addresses user vs. team role-bindings as distinct subresources (`rolebindings/users` vs `rolebindings/teams`) so they don't alias each other in Zanzana. The access-control stamping in user/team search uses `FilterAuthorized`, and without a subresource on the item it couldn't express that check.

The rest of the chain already supports subresources end to end:
- `types.BatchCheckItem` has `Subresource`,
- `ClientImpl.BatchCheck` already maps `check.Subresource` into the proto request,
- the proto `BatchCheckItem` has a `subresource` field (field 7).

The convenience wrapper was the only gap. This closes it.

## Tests

`TestFilterAuthorized_ForwardsSubresource` sets `Subresource` on the convenience item and asserts it reaches the recorded proto check. `go test ./authz/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)