### PR TITLE
feat(authn): add Extra claims and configurable headers to IDTokenSigner

### DIFF
--- a/authn/config.go
+++ b/authn/config.go
@@ -37,3 +37,15 @@ func (c *TokenExchangeConfig) RegisterFlags(prefix string, fs *flag.FlagSet) {
 	fs.StringVar(&c.Token, prefix+".token", "", "Token used to perform the exchange request.")
 	fs.StringVar(&c.TokenExchangeURL, prefix+".token-exchange-url", "", "Url called to perform exchange request.")
 }
+
+type IDTokenSignerConfig struct {
+	// Token used to authenticate the sign request.
+	Token string `yaml:"token"`
+	// URL called to sign ID tokens.
+	SignIDTokenURL string `yaml:"signIdTokenUrl"`
+}
+
+func (c *IDTokenSignerConfig) RegisterFlags(prefix string, fs *flag.FlagSet) {
+	fs.StringVar(&c.Token, prefix+".token", "", "Token used to authenticate the sign request.")
+	fs.StringVar(&c.SignIDTokenURL, prefix+".sign-id-token-url", "", "URL called to sign ID tokens.")
+}

--- a/authn/errors.go
+++ b/authn/errors.go
@@ -17,10 +17,11 @@ var (
 	ErrInvalidAudience      = fmt.Errorf("%w: invalid audience", errInvalidToken)
 	ErrMissingRequiredToken = fmt.Errorf("%w: missing required token", errInvalidToken)
 
-	ErrMissingConfig           = errors.New("missing config")
-	ErrMissingNamespace        = errors.New("missing required namespace")
-	ErrMissingAudiences        = errors.New("missing required audiences")
-	ErrInvalidExchangeResponse = errors.New("invalid exchange response")
+	ErrMissingConfig              = errors.New("missing config")
+	ErrMissingNamespace           = errors.New("missing required namespace")
+	ErrMissingAudiences           = errors.New("missing required audiences")
+	ErrInvalidExchangeResponse    = errors.New("invalid exchange response")
+	ErrInvalidSignIDTokenResponse = errors.New("invalid sign ID token response")
 )
 
 func IsUnauthenticatedErr(err error) bool {

--- a/authn/id_token_signer.go
+++ b/authn/id_token_signer.go
@@ -1,0 +1,265 @@
+package authn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/go-jose/go-jose/v4/jwt"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/grafana/authlib/cache"
+	"github.com/grafana/authlib/internal/httpclient"
+	"github.com/grafana/dskit/backoff"
+)
+
+// IDTokenSigner signs ID tokens via the auth API.
+type IDTokenSigner interface {
+	SignIDToken(ctx context.Context, r SignIDTokenRequest) (*SignIDTokenResponse, error)
+}
+
+var _ IDTokenSigner = &IDTokenSignerClient{}
+
+// IDTokenSignerClientOpts allows setting custom parameters during construction.
+type IDTokenSignerClientOpts func(c *IDTokenSignerClient)
+
+// WithIDTokenSignerHTTPClient allows setting the HTTP client to be used by the ID token signer client.
+func WithIDTokenSignerHTTPClient(client *http.Client) IDTokenSignerClientOpts {
+	return func(c *IDTokenSignerClient) {
+		c.client = client
+	}
+}
+
+// WithIDTokenSignerCache allows setting the cache to be used by the ID token signer client.
+func WithIDTokenSignerCache(cache cache.Cache) IDTokenSignerClientOpts {
+	return func(c *IDTokenSignerClient) {
+		c.cache = cache
+	}
+}
+
+// WithIDTokenSignerTracer allows setting the tracer to be used by the ID token signer client.
+func WithIDTokenSignerTracer(tracer trace.Tracer) IDTokenSignerClientOpts {
+	return func(c *IDTokenSignerClient) {
+		c.tracer = tracer
+	}
+}
+
+func NewIDTokenSignerClient(cfg IDTokenSignerConfig, opts ...IDTokenSignerClientOpts) (*IDTokenSignerClient, error) {
+	if cfg.Token == "" {
+		return nil, fmt.Errorf("%w: missing required token", ErrMissingConfig)
+	}
+
+	if cfg.SignIDTokenURL == "" {
+		return nil, fmt.Errorf("%w: missing required sign ID token url", ErrMissingConfig)
+	}
+
+	c := &IDTokenSignerClient{
+		cfg:     cfg,
+		singlef: singleflight.Group{},
+		tracer:  noop.NewTracerProvider().Tracer("authn.IDTokenSignerClient"),
+		backoffCfg: backoff.Config{
+			MaxBackoff: time.Second,
+			MinBackoff: 250 * time.Millisecond,
+			MaxRetries: 3,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	if c.client == nil {
+		c.client = httpclient.New()
+	}
+
+	if c.cache == nil {
+		c.cache = cache.NewLocalCache(cache.Config{
+			CleanupInterval: 5 * time.Minute,
+		})
+	}
+
+	return c, nil
+}
+
+type IDTokenSignerClient struct {
+	cache      cache.Cache
+	cfg        IDTokenSignerConfig
+	client     *http.Client
+	singlef    singleflight.Group
+	tracer     trace.Tracer
+	backoffCfg backoff.Config
+}
+
+type SignIDTokenRequest struct {
+	// Subject is the identity to sign the ID token for (e.g. "user:1").
+	Subject string
+	// Namespace is the namespace to scope the token to (e.g. "stacks-12345").
+	Namespace string
+}
+
+type SignIDTokenResponse struct {
+	Token string
+}
+
+// signIDTokenRequestBody is the JSON body sent to the auth API.
+type signIDTokenRequestBody struct {
+	Claims    signIDTokenClaims `json:"claims"`
+	Namespace string            `json:"namespace"`
+}
+
+type signIDTokenClaims struct {
+	Subject string `json:"sub"`
+}
+
+func (r SignIDTokenRequest) hash() string {
+	return r.Subject + "-" + r.Namespace
+}
+
+type signIDTokenResponseBody struct {
+	Data   signIDTokenData `json:"data"`
+	Status string          `json:"status"`
+	Error  string          `json:"error"`
+}
+
+type signIDTokenData struct {
+	Token string `json:"token"`
+}
+
+func (c *IDTokenSignerClient) SignIDToken(ctx context.Context, r SignIDTokenRequest) (*SignIDTokenResponse, error) {
+	ctx, span := c.tracer.Start(ctx, "authn.IDTokenSignerClient.SignIDToken")
+	defer span.End()
+	span.SetAttributes(attribute.Bool("cache_hit", false))
+
+	if r.Subject == "" {
+		return nil, fmt.Errorf("%w: missing required subject", ErrMissingConfig)
+	}
+
+	if r.Namespace == "" {
+		return nil, ErrMissingNamespace
+	}
+
+	key := r.hash()
+	token, ok := c.getCache(ctx, key)
+	if ok {
+		span.SetAttributes(attribute.Bool("cache_hit", true))
+		return &SignIDTokenResponse{Token: token}, nil
+	}
+
+	resp, err, _ := c.singlef.Do(key, func() (interface{}, error) {
+		body := signIDTokenRequestBody{
+			Claims:    signIDTokenClaims{Subject: r.Subject},
+			Namespace: r.Namespace,
+		}
+
+		data, err := json.Marshal(&body)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidSignIDTokenResponse, err)
+		}
+
+		b := backoff.New(ctx, c.backoffCfg)
+
+		var req *http.Request
+		var res *http.Response
+		for b.Ongoing() {
+			req, err = http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.SignIDTokenURL, bytes.NewReader(data))
+			if err != nil {
+				return nil, fmt.Errorf("failed to build http request: %w", err)
+			}
+
+			res, err = c.client.Do(c.withHeaders(req))
+			addResponseInformationToSpan(span, res, err)
+			if shouldRetry(res, err) {
+				if res != nil {
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}
+
+				b.Wait()
+				continue
+			}
+
+			defer func() { _ = res.Body.Close() }()
+			break
+		}
+
+		if err != nil || b.Err() != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidSignIDTokenResponse, errors.Join(b.Err(), err))
+		}
+
+		if res.StatusCode >= http.StatusInternalServerError {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidSignIDTokenResponse, res.Status)
+		}
+
+		response := signIDTokenResponseBody{}
+		if err := json.NewDecoder(res.Body).Decode(&response); err != nil {
+			return nil, err
+		}
+
+		if res.StatusCode != http.StatusOK {
+			if response.Error != "" {
+				return nil, fmt.Errorf("%w: %s", ErrInvalidSignIDTokenResponse, response.Error)
+			}
+			return nil, fmt.Errorf("%w: %s", ErrInvalidSignIDTokenResponse, res.Status)
+		}
+
+		_ = c.setCache(ctx, response.Data.Token, key)
+		return response, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := resp.(signIDTokenResponseBody)
+	return &SignIDTokenResponse{Token: response.Data.Token}, nil
+}
+
+func (c *IDTokenSignerClient) withHeaders(r *http.Request) *http.Request {
+	r.Header.Set("Authorization", "Bearer "+c.cfg.Token)
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json")
+	r.Header.Set("User-Agent", "authlib-client")
+
+	// Always propagate system token headers.
+	// These will be ignored for non system tokens.
+	r.Header.Set("X-Org-ID", "0")
+	r.Header.Set("X-Realms", `[{"type": "system", "identifier": "system"}]`)
+
+	// Propagate OpenTelemetry context headers.
+	otel.GetTextMapPropagator().Inject(r.Context(), propagation.HeaderCarrier(r.Header))
+
+	return r
+}
+
+func (c *IDTokenSignerClient) getCache(ctx context.Context, key string) (string, bool) {
+	if token, err := c.cache.Get(ctx, key); err == nil {
+		return string(token), true
+	}
+	return "", false
+}
+
+func (c *IDTokenSignerClient) setCache(ctx context.Context, token string, key string) error {
+	const cacheLeeway = 15 * time.Second
+
+	parsed, err := jwt.ParseSigned(token, tokenSignAlgs)
+	if err != nil {
+		return fmt.Errorf("failed to parse token: %v", err)
+	}
+
+	var claims jwt.Claims
+	if err = parsed.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		return fmt.Errorf("failed to extract claims from the token: %v", err)
+	}
+
+	return c.cache.Set(ctx, key, []byte(token), time.Until(claims.Expiry.Time())-cacheLeeway)
+}

--- a/authn/id_token_signer.go
+++ b/authn/id_token_signer.go
@@ -3,6 +3,8 @@ package authn
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,7 +27,24 @@ import (
 
 // IDTokenSigner signs ID tokens via the auth API.
 type IDTokenSigner interface {
-	SignIDToken(ctx context.Context, r SignIDTokenRequest) (*SignIDTokenResponse, error)
+	SignIDToken(ctx context.Context, r SignIDTokenRequest, opts ...SignIDTokenOption) (*SignIDTokenResponse, error)
+}
+
+// SignIDTokenOption is a function that modifies the outgoing HTTP request for
+// a single SignIDToken call. It is applied after default and client-level
+// headers, so it can override anything. Use this for per-request concerns
+// like setting tenant-scoped X-Org-ID / X-Realms headers.
+type SignIDTokenOption func(*http.Request)
+
+// WithSignerHeaders returns a SignIDTokenOption that sets the given HTTP
+// headers on the request. This is a convenience helper for the common case
+// of overriding headers per-request (e.g. X-Org-ID, X-Realms).
+func WithSignerHeaders(headers map[string]string) SignIDTokenOption {
+	return func(r *http.Request) {
+		for k, v := range headers {
+			r.Header.Set(k, v)
+		}
+	}
 }
 
 var _ IDTokenSigner = &IDTokenSignerClient{}
@@ -53,6 +72,7 @@ func WithIDTokenSignerTracer(tracer trace.Tracer) IDTokenSignerClientOpts {
 		c.tracer = tracer
 	}
 }
+
 
 func NewIDTokenSignerClient(cfg IDTokenSignerConfig, opts ...IDTokenSignerClientOpts) (*IDTokenSignerClient, error) {
 	if cfg.Token == "" {
@@ -92,12 +112,12 @@ func NewIDTokenSignerClient(cfg IDTokenSignerConfig, opts ...IDTokenSignerClient
 }
 
 type IDTokenSignerClient struct {
-	cache      cache.Cache
-	cfg        IDTokenSignerConfig
-	client     *http.Client
-	singlef    singleflight.Group
-	tracer     trace.Tracer
-	backoffCfg backoff.Config
+	cache        cache.Cache
+	cfg          IDTokenSignerConfig
+	client       *http.Client
+	singlef      singleflight.Group
+	tracer       trace.Tracer
+	backoffCfg   backoff.Config
 }
 
 type SignIDTokenRequest struct {
@@ -105,6 +125,10 @@ type SignIDTokenRequest struct {
 	Subject string
 	// Namespace is the namespace to scope the token to (e.g. "stacks-12345").
 	Namespace string
+	// Extra contains additional claims to include in the signed token
+	// (e.g. email, username, type, role). Keys that conflict with
+	// registered JWT claims are stripped server-side.
+	Extra map[string]any
 }
 
 type SignIDTokenResponse struct {
@@ -115,6 +139,7 @@ type SignIDTokenResponse struct {
 type signIDTokenRequestBody struct {
 	Claims    signIDTokenClaims `json:"claims"`
 	Namespace string            `json:"namespace"`
+	Extra     map[string]any    `json:"extra,omitempty"`
 }
 
 type signIDTokenClaims struct {
@@ -122,7 +147,17 @@ type signIDTokenClaims struct {
 }
 
 func (r SignIDTokenRequest) hash() string {
-	return r.Subject + "-" + r.Namespace
+	if len(r.Extra) == 0 {
+		return r.Subject + "-" + r.Namespace
+	}
+	h := sha256.New()
+	h.Write([]byte(r.Subject))
+	h.Write([]byte{0})
+	h.Write([]byte(r.Namespace))
+	h.Write([]byte{0})
+	data, _ := json.Marshal(r.Extra)
+	h.Write(data)
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 type signIDTokenResponseBody struct {
@@ -135,7 +170,7 @@ type signIDTokenData struct {
 	Token string `json:"token"`
 }
 
-func (c *IDTokenSignerClient) SignIDToken(ctx context.Context, r SignIDTokenRequest) (*SignIDTokenResponse, error) {
+func (c *IDTokenSignerClient) SignIDToken(ctx context.Context, r SignIDTokenRequest, opts ...SignIDTokenOption) (*SignIDTokenResponse, error) {
 	ctx, span := c.tracer.Start(ctx, "authn.IDTokenSignerClient.SignIDToken")
 	defer span.End()
 	span.SetAttributes(attribute.Bool("cache_hit", false))
@@ -159,6 +194,7 @@ func (c *IDTokenSignerClient) SignIDToken(ctx context.Context, r SignIDTokenRequ
 		body := signIDTokenRequestBody{
 			Claims:    signIDTokenClaims{Subject: r.Subject},
 			Namespace: r.Namespace,
+			Extra:     r.Extra,
 		}
 
 		data, err := json.Marshal(&body)
@@ -176,7 +212,12 @@ func (c *IDTokenSignerClient) SignIDToken(ctx context.Context, r SignIDTokenRequ
 				return nil, fmt.Errorf("failed to build http request: %w", err)
 			}
 
-			res, err = c.client.Do(c.withHeaders(req))
+			req = c.withHeaders(req)
+			for _, opt := range opts {
+				opt(req)
+			}
+
+			res, err = c.client.Do(req)
 			addResponseInformationToSpan(span, res, err)
 			if shouldRetry(res, err) {
 				if res != nil {
@@ -213,15 +254,14 @@ func (c *IDTokenSignerClient) SignIDToken(ctx context.Context, r SignIDTokenRequ
 		}
 
 		_ = c.setCache(ctx, response.Data.Token, key)
-		return response, nil
+		return &SignIDTokenResponse{Token: response.Data.Token}, nil
 	})
 
 	if err != nil {
 		return nil, err
 	}
 
-	response := resp.(signIDTokenResponseBody)
-	return &SignIDTokenResponse{Token: response.Data.Token}, nil
+	return resp.(*SignIDTokenResponse), nil
 }
 
 func (c *IDTokenSignerClient) withHeaders(r *http.Request) *http.Request {
@@ -230,8 +270,7 @@ func (c *IDTokenSignerClient) withHeaders(r *http.Request) *http.Request {
 	r.Header.Set("Accept", "application/json")
 	r.Header.Set("User-Agent", "authlib-client")
 
-	// Always propagate system token headers.
-	// These will be ignored for non system tokens.
+	// Default system-scoped headers.
 	r.Header.Set("X-Org-ID", "0")
 	r.Header.Set("X-Realms", `[{"type": "system", "identifier": "system"}]`)
 

--- a/authn/id_token_signer_test.go
+++ b/authn/id_token_signer_test.go
@@ -77,6 +77,7 @@ func Test_IDTokenSignerClient_SignIDToken(t *testing.T) {
 		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Bearer some-token", r.Header.Get("Authorization"))
 			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			assert.Equal(t, "0", r.Header.Get("X-Org-ID"))
 
 			var body signIDTokenRequestBody
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -91,6 +92,68 @@ func Test_IDTokenSignerClient_SignIDToken(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		assert.NotEmpty(t, res.Token)
+	})
+
+	t.Run("should send extra claims in request body", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var body signIDTokenRequestBody
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "user:1", body.Claims.Subject)
+			assert.Equal(t, "stacks-1", body.Namespace)
+			assert.Equal(t, "alice@example.com", body.Extra["email"])
+			assert.Equal(t, "alice", body.Extra["username"])
+			assert.Equal(t, "user", body.Extra["type"])
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{
+			Subject:   "user:1",
+			Namespace: "stacks-1",
+			Extra: map[string]any{
+				"email":    "alice@example.com",
+				"username": "alice",
+				"type":     "user",
+			},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.NotEmpty(t, res.Token)
+	})
+
+	t.Run("should use per-request WithSignerHeaders to override defaults", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "12345", r.Header.Get("X-Org-ID"))
+			assert.Equal(t, `[{"type":"stack","identifier":"12345"}]`, r.Header.Get("X-Realms"))
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-1"}, WithSignerHeaders(map[string]string{
+			"X-Org-ID": "12345",
+			"X-Realms": `[{"type":"stack","identifier":"12345"}]`,
+		}))
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+	})
+
+	t.Run("should use per-request func option to modify request", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "42", r.Header.Get("X-Org-ID"))
+			assert.Equal(t, "custom-value", r.Header.Get("X-Custom"))
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-1"}, func(r *http.Request) {
+			r.Header.Set("X-Org-ID", "42")
+			r.Header.Set("X-Custom", "custom-value")
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
 	})
 
 	t.Run("should cache and return token on successful sign request", func(t *testing.T) {
@@ -123,6 +186,26 @@ func Test_IDTokenSignerClient_SignIDToken(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, res)
 		require.Equal(t, 3, calls)
+
+		// same subject/namespace but different extra claims should make a new request
+		res, err = c.SignIDToken(context.Background(), SignIDTokenRequest{
+			Subject:   "user:1",
+			Namespace: "stacks-1",
+			Extra:     map[string]any{"email": "alice@example.com"},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 4, calls)
+
+		// same request with extra should hit cache
+		res, err = c.SignIDToken(context.Background(), SignIDTokenRequest{
+			Subject:   "user:1",
+			Namespace: "stacks-1",
+			Extra:     map[string]any{"email": "alice@example.com"},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 4, calls)
 	})
 
 	t.Run("should return error with message from server", func(t *testing.T) {

--- a/authn/id_token_signer_test.go
+++ b/authn/id_token_signer_test.go
@@ -1,0 +1,139 @@
+package authn
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIDTokenSignerClient(t *testing.T) {
+	t.Run("should not be able to create client without token", func(t *testing.T) {
+		_, err := NewIDTokenSignerClient(IDTokenSignerConfig{
+			SignIDTokenURL: "some-url",
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingConfig)
+	})
+
+	t.Run("should not be able to create client without url", func(t *testing.T) {
+		_, err := NewIDTokenSignerClient(IDTokenSignerConfig{
+			Token: "some-token",
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrMissingConfig)
+	})
+
+	t.Run("should be able to create client", func(t *testing.T) {
+		_, err := NewIDTokenSignerClient(IDTokenSignerConfig{
+			Token:          "some-token",
+			SignIDTokenURL: "some-url",
+		})
+		require.NoError(t, err)
+	})
+}
+
+func Test_IDTokenSignerClient_SignIDToken(t *testing.T) {
+	expiresIn := 10 * time.Minute
+	setup := func(srv *httptest.Server, opts ...IDTokenSignerClientOpts) *IDTokenSignerClient {
+		c, err := NewIDTokenSignerClient(IDTokenSignerConfig{
+			Token:          "some-token",
+			SignIDTokenURL: srv.URL,
+		}, opts...)
+		require.NoError(t, err)
+		return c
+	}
+
+	t.Run("should return error if subject is empty", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})))
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Namespace: "stacks-1"})
+		assert.Error(t, err)
+		assert.Nil(t, res)
+	})
+
+	t.Run("should return error if namespace is empty", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})))
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1"})
+		assert.ErrorIs(t, err, ErrMissingNamespace)
+		assert.Nil(t, res)
+	})
+
+	t.Run("should return error for unexpected server response", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("{}"))
+		})))
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-1"})
+		assert.ErrorIs(t, err, ErrInvalidSignIDTokenResponse)
+		assert.Nil(t, res)
+	})
+
+	t.Run("should send correct request body and headers", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer some-token", r.Header.Get("Authorization"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			var body signIDTokenRequestBody
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "user:1", body.Claims.Subject)
+			assert.Equal(t, "stacks-12345", body.Namespace)
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-12345"})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.NotEmpty(t, res.Token)
+	})
+
+	t.Run("should cache and return token on successful sign request", func(t *testing.T) {
+		var calls int
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-1"})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 1, calls)
+
+		// same subject and namespace should load token from cache
+		res, err = c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-1"})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 1, calls)
+
+		// different namespace should make a new request
+		res, err = c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-2"})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 2, calls)
+
+		// different subject should make a new request
+		res, err = c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:2", Namespace: "stacks-1"})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+		require.Equal(t, 3, calls)
+	})
+
+	t.Run("should return error with message from server", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"status": "error", "error": "forbidden namespace"}`))
+		})))
+
+		res, err := c.SignIDToken(context.Background(), SignIDTokenRequest{Subject: "user:1", Namespace: "stacks-1"})
+		assert.ErrorIs(t, err, ErrInvalidSignIDTokenResponse)
+		assert.Contains(t, err.Error(), "forbidden namespace")
+		assert.Nil(t, res)
+	})
+}


### PR DESCRIPTION
Extends the ID token signer client so it can be reused by services that need to pass identity claims (email, username, type, etc.) and customize the request headers for stack-scoped callers.

> **Note:** This PR is meant to be merged into #296 first.

**Changes:**
- Add `Extra map[string]any` to `SignIDTokenRequest` for additional token claims
- Add `WithIDTokenSignerHeaders` option to override default system-scoped headers
- Cache key accounts for `Extra` to avoid collisions

Made with [Cursor](https://cursor.com)