### PR TITLE
feat(authn): Support subject identity in token exchange request

### DIFF
--- a/authn/errors.go
+++ b/authn/errors.go
@@ -17,10 +17,11 @@ var (
 	ErrInvalidAudience      = fmt.Errorf("%w: invalid audience", errInvalidToken)
 	ErrMissingRequiredToken = fmt.Errorf("%w: missing required token", errInvalidToken)
 
-	ErrMissingConfig           = errors.New("missing config")
-	ErrMissingNamespace        = errors.New("missing required namespace")
-	ErrMissingAudiences        = errors.New("missing required audiences")
-	ErrInvalidExchangeResponse = errors.New("invalid exchange response")
+	ErrMissingConfig            = errors.New("missing config")
+	ErrMissingNamespace         = errors.New("missing required namespace")
+	ErrMissingAudiences         = errors.New("missing required audiences")
+	ErrInvalidExchangeResponse  = errors.New("invalid exchange response")
+	ErrMutuallyExclusiveSubject = errors.New("subject and subjectToken are mutually exclusive")
 )
 
 func IsUnauthenticatedErr(err error) bool {

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -117,12 +117,34 @@ type TokenExchangeRequest struct {
 	Audiences []string `json:"audiences"`
 	// [Optional] SubjectToken is the token to exchange in case of a token exchange request.
 	SubjectToken string `json:"subjectToken,omitempty"`
+	// [Optional] Subject is a user identity to sign an on-behalf-of token for,
+	// without first obtaining a signed subjectToken. It is mutually exclusive
+	// with SubjectToken. The auth API requires the caller to hold the
+	// grafana-id-token:sign scope (in addition to access-token:sign) to use it.
+	Subject *TokenExchangeSubject `json:"subject,omitempty"`
 	// [Optional] ExpiresIn is the duration, in seconds, before the token expires.
 	ExpiresIn *int `json:"expiresIn,omitempty"`
 	// [Optional] RestrictedDelegatedPermissions narrows the token's delegated permissions
 	// to the intersection of this list and the CAP's delegated permissions. If omitted,
 	// the full set of CAP delegated permissions is used.
 	RestrictedDelegatedPermissions []string `json:"restrictedDelegatedPermissions,omitempty"`
+}
+
+// TokenExchangeSubject carries a user identity that the caller asserts when
+// exchanging for an on-behalf-of access token. Its JSON shape matches the
+// auth API's sign-access-token "subject" object and mirrors the claim set of
+// an ID token.
+type TokenExchangeSubject struct {
+	Identifier      string   `json:"identifier"`
+	Type            string   `json:"type"`
+	Namespace       string   `json:"namespace"`
+	AuthenticatedBy string   `json:"authenticatedBy,omitempty"`
+	Email           string   `json:"email,omitempty"`
+	EmailVerified   bool     `json:"email_verified,omitempty"`
+	Username        string   `json:"username,omitempty"`
+	DisplayName     string   `json:"name,omitempty"`
+	Role            string   `json:"role,omitempty"`
+	Groups          []string `json:"groups,omitempty"`
 }
 
 type TokenExchangeResponse struct {
@@ -136,6 +158,14 @@ func (r TokenExchangeRequest) hash() string {
 	sort.Strings(r.Audiences)
 	br.WriteString(strings.Join(r.Audiences, "-"))
 	br.WriteString(subjectCacheKey(r.SubjectToken))
+	if r.Subject != nil {
+		// json.Marshal of a struct is deterministic (field order is stable), so
+		// this yields a stable cache key that differs per subject identity.
+		if data, err := json.Marshal(r.Subject); err == nil {
+			br.WriteByte('-')
+			br.Write(data)
+		}
+	}
 	if len(r.RestrictedDelegatedPermissions) > 0 {
 		br.WriteByte('-')
 		sorted := make([]string, len(r.RestrictedDelegatedPermissions))
@@ -218,6 +248,10 @@ func (c *TokenExchangeClient) Exchange(ctx context.Context, r TokenExchangeReque
 
 	if len(r.Audiences) == 0 {
 		return nil, ErrMissingAudiences
+	}
+
+	if r.Subject != nil && r.SubjectToken != "" {
+		return nil, ErrMutuallyExclusiveSubject
 	}
 
 	key := r.hash()

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -164,15 +164,20 @@ func (r TokenExchangeRequest) hash() (string, error) {
 	br.WriteString(strings.Join(r.Audiences, "-"))
 	br.WriteString(subjectTokenCacheKey(r.SubjectToken))
 	br.WriteString(subjectKey)
-	if len(r.RestrictedDelegatedPermissions) > 0 {
-		br.WriteByte('-')
-		sorted := make([]string, len(r.RestrictedDelegatedPermissions))
-		copy(sorted, r.RestrictedDelegatedPermissions)
-		sort.Strings(sorted)
-		br.WriteString(strings.Join(sorted, "-"))
-	}
+	br.WriteString(restrictedPermissionsCacheKey(r.RestrictedDelegatedPermissions))
 
 	return br.String(), nil
+}
+
+func restrictedPermissionsCacheKey(permissions []string) string {
+	if len(permissions) == 0 {
+		return ""
+	}
+
+	sorted := make([]string, len(permissions))
+	copy(sorted, permissions)
+	sort.Strings(sorted)
+	return "-" + strings.Join(sorted, "-")
 }
 
 type subjectTokenCacheClaims struct {

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -151,14 +151,19 @@ type TokenExchangeResponse struct {
 	Token string
 }
 
-func (r TokenExchangeRequest) hash() string {
+func (r TokenExchangeRequest) hash() (string, error) {
+	subjectKey, err := subjectCacheKey(r.Subject)
+	if err != nil {
+		return "", err
+	}
+
 	br := strings.Builder{}
 	br.WriteString(r.Namespace)
 	br.WriteByte('-')
 	sort.Strings(r.Audiences)
 	br.WriteString(strings.Join(r.Audiences, "-"))
 	br.WriteString(subjectTokenCacheKey(r.SubjectToken))
-	br.WriteString(subjectCacheKey(r.Subject))
+	br.WriteString(subjectKey)
 	if len(r.RestrictedDelegatedPermissions) > 0 {
 		br.WriteByte('-')
 		sorted := make([]string, len(r.RestrictedDelegatedPermissions))
@@ -167,7 +172,7 @@ func (r TokenExchangeRequest) hash() string {
 		br.WriteString(strings.Join(sorted, "-"))
 	}
 
-	return br.String()
+	return br.String(), nil
 }
 
 type subjectTokenCacheClaims struct {
@@ -220,9 +225,9 @@ func flattenedActorSubjects(actor *ActorClaims) []string {
 	return parts
 }
 
-func subjectCacheKey(subject *TokenExchangeSubject) string {
+func subjectCacheKey(subject *TokenExchangeSubject) (string, error) {
 	if subject == nil {
-		return ""
+		return "", nil
 	}
 
 	s := *subject
@@ -235,9 +240,9 @@ func subjectCacheKey(subject *TokenExchangeSubject) string {
 
 	data, err := json.Marshal(s)
 	if err != nil {
-		return ""
+		return "", err
 	}
-	return "-" + string(data)
+	return "-" + string(data), nil
 }
 
 type tokenExchangeResponse struct {
@@ -267,7 +272,11 @@ func (c *TokenExchangeClient) Exchange(ctx context.Context, r TokenExchangeReque
 		return nil, ErrMutuallyExclusiveSubject
 	}
 
-	key := r.hash()
+	key, err := r.hash()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build token exchange cache key: %w", err)
+	}
+
 	token, ok := c.getCache(ctx, key)
 	if ok {
 		span.SetAttributes(attribute.Bool("cache_hit", true))

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -157,15 +157,8 @@ func (r TokenExchangeRequest) hash() string {
 	br.WriteByte('-')
 	sort.Strings(r.Audiences)
 	br.WriteString(strings.Join(r.Audiences, "-"))
-	br.WriteString(subjectCacheKey(r.SubjectToken))
-	if r.Subject != nil {
-		// json.Marshal of a struct is deterministic (field order is stable), so
-		// this yields a stable cache key that differs per subject identity.
-		if data, err := json.Marshal(r.Subject); err == nil {
-			br.WriteByte('-')
-			br.Write(data)
-		}
-	}
+	br.WriteString(subjectTokenCacheKey(r.SubjectToken))
+	br.WriteString(subjectCacheKey(r.Subject))
 	if len(r.RestrictedDelegatedPermissions) > 0 {
 		br.WriteByte('-')
 		sorted := make([]string, len(r.RestrictedDelegatedPermissions))
@@ -182,7 +175,7 @@ type subjectTokenCacheClaims struct {
 	Actor *ActorClaims `json:"act,omitempty"`
 }
 
-func subjectCacheKey(subjectToken string) string {
+func subjectTokenCacheKey(subjectToken string) string {
 	if subjectToken == "" {
 		return ""
 	}
@@ -225,6 +218,26 @@ func flattenedActorSubjects(actor *ActorClaims) []string {
 		parts[i], parts[j] = parts[j], parts[i]
 	}
 	return parts
+}
+
+func subjectCacheKey(subject *TokenExchangeSubject) string {
+	if subject == nil {
+		return ""
+	}
+
+	s := *subject
+	if len(s.Groups) > 0 {
+		groups := make([]string, len(s.Groups))
+		copy(groups, s.Groups)
+		sort.Strings(groups)
+		s.Groups = groups
+	}
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		return ""
+	}
+	return "-" + string(data)
 }
 
 type tokenExchangeResponse struct {

--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -160,8 +160,10 @@ func (r TokenExchangeRequest) hash() (string, error) {
 	br := strings.Builder{}
 	br.WriteString(r.Namespace)
 	br.WriteByte('-')
-	sort.Strings(r.Audiences)
-	br.WriteString(strings.Join(r.Audiences, "-"))
+	audiences := make([]string, len(r.Audiences))
+	copy(audiences, r.Audiences)
+	sort.Strings(audiences)
+	br.WriteString(strings.Join(audiences, "-"))
 	br.WriteString(subjectTokenCacheKey(r.SubjectToken))
 	br.WriteString(subjectKey)
 	br.WriteString(restrictedPermissionsCacheKey(r.RestrictedDelegatedPermissions))

--- a/authn/token_exchange_test.go
+++ b/authn/token_exchange_test.go
@@ -186,6 +186,85 @@ func Test_TokenExchangeClient_Exchange(t *testing.T) {
 		require.InDelta(t, expectedExpiry.Unix(), claims.Expiry.Time().Unix(), 1)
 	})
 
+	t.Run("should include subject in request when provided", func(t *testing.T) {
+		var got TokenExchangeRequest
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestBody, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(requestBody, &got))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{
+			Namespace: "stacks-1",
+			Audiences: []string{"some-service"},
+			Subject: &TokenExchangeSubject{
+				Identifier: "1",
+				Type:       "user",
+				Namespace:  "stacks-1",
+				Email:      "user@example.com",
+				Username:   "user",
+			},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, res)
+
+		require.Empty(t, got.SubjectToken)
+		require.NotNil(t, got.Subject)
+		require.Equal(t, "1", got.Subject.Identifier)
+		require.Equal(t, "user", got.Subject.Type)
+		require.Equal(t, "stacks-1", got.Subject.Namespace)
+		require.Equal(t, "user@example.com", got.Subject.Email)
+		require.Equal(t, "user", got.Subject.Username)
+	})
+
+	t.Run("should return error when subject and subjectToken are both set", func(t *testing.T) {
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		res, err := c.Exchange(context.Background(), TokenExchangeRequest{
+			Namespace:    "stacks-1",
+			Audiences:    []string{"some-service"},
+			SubjectToken: signAccessToken(t, expiresIn),
+			Subject: &TokenExchangeSubject{
+				Identifier: "1",
+				Type:       "user",
+				Namespace:  "stacks-1",
+			},
+		})
+		require.ErrorIs(t, err, ErrMutuallyExclusiveSubject)
+		require.Nil(t, res)
+	})
+
+	t.Run("should not reuse cache for different subjects", func(t *testing.T) {
+		var calls int
+		c := setup(httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"token": "` + signAccessToken(t, expiresIn) + `"}}`))
+		})))
+
+		subject1 := &TokenExchangeSubject{Identifier: "1", Type: "user", Namespace: "stacks-1"}
+		subject2 := &TokenExchangeSubject{Identifier: "2", Type: "user", Namespace: "stacks-1"}
+
+		_, err := c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stacks-1", Audiences: []string{"some-service"}, Subject: subject1})
+		assert.NoError(t, err)
+		require.Equal(t, 1, calls)
+
+		// Same subject should reuse the cache.
+		_, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stacks-1", Audiences: []string{"some-service"}, Subject: subject1})
+		assert.NoError(t, err)
+		require.Equal(t, 1, calls)
+
+		// Different subject should miss the cache.
+		_, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stacks-1", Audiences: []string{"some-service"}, Subject: subject2})
+		assert.NoError(t, err)
+		require.Equal(t, 2, calls)
+	})
+
 	t.Run("should use an alternate cache if provided", func(t *testing.T) {
 		testcache := &testCache{data: make(map[string][]byte)}
 


### PR DESCRIPTION
## Why

Today, obtaining an on-behalf-of (OBO) access token through the exchange client requires a `subjectToken`, either an existing access token or an ID token. Callers that only hold a user identity must first sign an ID token and then exchange it, which is two round-trips and encourages standalone ID-token minting.

This lets callers pass a `subject` identity directly on the exchange request, so an identity-bearing access token can be obtained in one step, with no intermediate ID token required.

## What

- Add an optional `Subject` field to `TokenExchangeRequest`, backed by a new `TokenExchangeSubject` type whose JSON shape mirrors the sign-access-token `subject` object (`identifier`, `type`, `namespace`, `authenticatedBy`, `email`, `email_verified`, `username`, `name`, `role`, `groups`).
- `Subject` and `SubjectToken` are mutually exclusive; setting both returns the new `ErrMutuallyExclusiveSubject` error.
- Fold the subject into the request cache key so tokens for different identities are not shared.
- Add tests covering request propagation, mutual exclusivity, and per-subject cache isolation.