### PR TITLE
feat(authn): add Sub to TokenExchangeSubject

### DIFF
--- a/authn/token_exchange.go
+++ b/authn/token_exchange.go
@@ -135,6 +135,11 @@ type TokenExchangeRequest struct {
 // auth API's sign-access-token "subject" object and mirrors the claim set of
 // an ID token.
 type TokenExchangeSubject struct {
+	// Sub is the fully-typed subject as it appears in the ID token's `sub`
+	// claim (e.g. "user:1"). Its identifier part must be the numeric internal
+	// ID, which downstream Grafana resolves via strconv.ParseInt. When empty
+	// the auth API falls back to "<type>:<identifier>".
+	Sub             string   `json:"sub,omitempty"`
 	Identifier      string   `json:"identifier"`
 	Type            string   `json:"type"`
 	Namespace       string   `json:"namespace"`

--- a/authn/token_exchange_test.go
+++ b/authn/token_exchange_test.go
@@ -263,6 +263,18 @@ func Test_TokenExchangeClient_Exchange(t *testing.T) {
 		_, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stacks-1", Audiences: []string{"some-service"}, Subject: subject2})
 		assert.NoError(t, err)
 		require.Equal(t, 2, calls)
+
+		// Subjects differing only by Sub should miss the cache.
+		subject3 := &TokenExchangeSubject{Sub: "user:1", Identifier: "abc", Type: "user", Namespace: "stacks-1"}
+		subject4 := &TokenExchangeSubject{Sub: "user:2", Identifier: "abc", Type: "user", Namespace: "stacks-1"}
+
+		_, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stacks-1", Audiences: []string{"some-service"}, Subject: subject3})
+		assert.NoError(t, err)
+		require.Equal(t, 3, calls)
+
+		_, err = c.Exchange(context.Background(), TokenExchangeRequest{Namespace: "stacks-1", Audiences: []string{"some-service"}, Subject: subject4})
+		assert.NoError(t, err)
+		require.Equal(t, 4, calls)
 	})
 
 	t.Run("should use an alternate cache if provided", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an optional `Sub` field to `TokenExchangeSubject`, carrying the fully-typed subject as it appears in an ID token's `sub` claim (e.g. `user:1`), whose identifier part is the numeric internal ID.

Today `TokenExchangeSubject` only exposes `Identifier`, which the auth API uses both for the `sub` claim (as `<type>:<identifier>`) and for the ID-token `identifier` claim. Real ID tokens keep these distinct: `sub` = `user:<numericID>` and `identifier` = `<uid>`. Grafana's `ext_jwt` authenticator resolves the actor by running `strconv.ParseInt` on the id-part of the `act.sub` claim, so a UID-only identifier can never populate a valid `sub` — it fails with `unrecognized format for valid type user: strconv.ParseInt: parsing "<uid>": invalid syntax`.

This field lets callers (e.g. the authn-service minting on-behalf-of tokens via raw subject assertion) send both the numeric `sub` and the UID `identifier`, matching the claim set of a real ID token. When `Sub` is empty, the auth API falls back to the existing `<type>:<identifier>` behavior, so this is backwards compatible.

The field is included in the subject cache key automatically (the key is the JSON-marshaled subject), so subjects differing only by `Sub` correctly miss the cache.

## Test plan

- [x] `go test ./authn/` passes
- [x] Added a cache-key regression: subjects differing only by `Sub` miss the cache

Made with [Cursor](https://cursor.com)