### PR TITLE
Authz: prevent authorization cache key collisions

### DIFF
--- a/authz/client.go
+++ b/authz/client.go
@@ -455,7 +455,7 @@ func newOutgoingContext(ctx context.Context) context.Context {
 // -----
 
 func checkCacheKey(subj string, teams []string, req *types.CheckRequest, folder string) string {
-	return fmt.Sprintf("check-%s-%s-%s-%s-%s-%s-%s-%s-%s-%s", req.Namespace, subj, teamsCacheKey(teams), req.Group, req.Resource, req.Verb, req.Name, req.Subresource, req.Path, folder)
+	return authorizationCacheKey("check", req.Namespace, subj, teamsCacheKey(teams), req.Group, req.Resource, req.Verb, req.Name, req.Subresource, req.Path, folder)
 }
 
 type checkCacheEntry struct {
@@ -496,7 +496,19 @@ func (c *ClientImpl) getCachedCheck(ctx context.Context, key string) (bool, int6
 }
 
 func itemCheckerCacheKey(subj string, teams []string, req *types.ListRequest) string {
-	return fmt.Sprintf("list-%s-%s-%s-%s-%s-%s-%s", req.Namespace, subj, teamsCacheKey(teams), req.Group, req.Resource, req.Verb, req.Subresource)
+	return authorizationCacheKey("list", req.Namespace, subj, teamsCacheKey(teams), req.Group, req.Resource, req.Verb, req.Subresource)
+}
+
+func authorizationCacheKey(prefix string, fields ...string) string {
+	hash := sha256.New()
+	var length [8]byte
+	for _, field := range fields {
+		binary.BigEndian.PutUint64(length[:], uint64(len(field)))
+		_, _ = hash.Write(length[:])
+		_, _ = hash.Write([]byte(field))
+	}
+
+	return prefix + "-" + hex.EncodeToString(hash.Sum(nil))
 }
 
 func teamsCacheKey(teams []string) string {

--- a/authz/client_test.go
+++ b/authz/client_test.go
@@ -637,6 +637,87 @@ func TestClient_Check_Cache(t *testing.T) {
 	require.True(t, got.Allowed)
 }
 
+func TestClient_Check_CacheKeyCollision(t *testing.T) {
+	client, authz := setupAccessClient()
+	authz.checkRes = &authzv1.CheckResponse{Allowed: true}
+
+	caller := authn.NewIDTokenAuthInfo(
+		authn.Claims[authn.AccessTokenClaims]{
+			Claims: jwt.Claims{Subject: "service"},
+			Rest:   authn.AccessTokenClaims{Namespace: "stacks-12", DelegatedPermissions: []string{"dashboards.grafana.app/dashboards:get"}},
+		},
+		&authn.Claims[authn.IDTokenClaims]{
+			Claims: jwt.Claims{Subject: "user:1"},
+			Rest:   authn.IDTokenClaims{Namespace: "stacks-12"},
+		},
+	)
+
+	first := types.CheckRequest{
+		Namespace:   "stacks-12",
+		Group:       "dashboards.grafana.app",
+		Resource:    "dashboards",
+		Verb:        "get",
+		Name:        "resource-name",
+		Subresource: "status",
+	}
+	second := first
+	second.Name = "resource"
+	second.Subresource = "name-status"
+
+	got, err := client.Check(context.Background(), caller, first, "")
+	require.NoError(t, err)
+	require.True(t, got.Allowed)
+
+	authz.checkRes = &authzv1.CheckResponse{Allowed: false}
+	got, err = client.Check(context.Background(), caller, second, "")
+	require.NoError(t, err)
+	require.False(t, got.Allowed)
+	require.Len(t, authz.checkReqs, 2)
+}
+
+func TestAuthorizationCacheKeys(t *testing.T) {
+	checkOne := &types.CheckRequest{
+		Namespace:   "stacks-12",
+		Group:       "dashboards.grafana.app",
+		Resource:    "dashboards",
+		Verb:        "get",
+		Name:        "resource-name",
+		Subresource: "status",
+	}
+	checkTwo := *checkOne
+	checkTwo.Name = "resource"
+	checkTwo.Subresource = "name-status"
+
+	require.NotEqual(t,
+		checkCacheKey("user:1", []string{"team-a"}, checkOne, ""),
+		checkCacheKey("user:1", []string{"team-a"}, &checkTwo, ""),
+	)
+	require.Equal(t,
+		checkCacheKey("user:1", []string{"team-a", "team-b"}, checkOne, ""),
+		checkCacheKey("user:1", []string{"team-b", "team-a"}, checkOne, ""),
+	)
+	require.Equal(t,
+		checkCacheKey("user:1", []string{"team-a"}, checkOne, ""),
+		checkCacheKey("user:1", []string{"team-a"}, checkOne, ""),
+	)
+
+	listOne := &types.ListRequest{
+		Namespace:   "stacks-12",
+		Group:       "dashboards.grafana.app",
+		Resource:    "dashboards-view",
+		Verb:        "get",
+		Subresource: "status",
+	}
+	listTwo := *listOne
+	listTwo.Resource = "dashboards"
+	listTwo.Verb = "view-get"
+
+	require.NotEqual(t,
+		itemCheckerCacheKey("user:1", []string{"team-a"}, listOne),
+		itemCheckerCacheKey("user:1", []string{"team-a"}, &listTwo),
+	)
+}
+
 func TestClient_Check_SkipCache(t *testing.T) {
 	client, authz := setupAccessClient()
 	authz.checkRes = &authzv1.CheckResponse{Allowed: true}


### PR DESCRIPTION
## What changed

- build check and list authorization cache keys from a SHA-256 hash of length-prefixed fields
- preserve distinct key prefixes and order-independent team handling
- add regression coverage for ambiguous resource name/subresource combinations and list-key field boundaries

## Why

Authorization cache keys previously joined fields with `-`. Kubernetes resource names, namespaces, and subresources can contain dashes, so different authorization requests could serialize to the same cache key. An authenticated user could potentially receive a cached allowed result for a different resource or subresource.

The new encoding preserves field boundaries before hashing, so distinct authorization requests cannot collide through delimiter ambiguity. Existing cache entries become unreachable after upgrade and expire normally.

## Validation

- `go test ./authz` (155 tests passed)
- `go test ./...` (276 tests passed)
- `git diff --check`
