### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`authlib` is a pure Go library (shared authn/authz SDK). It has **no runtime services** and
+needs nothing beyond Go. Standard commands are in `README.md`; notes below cover non-obvious caveats.
+
+- It is a **multi-module `go.work`** workspace (`.` and `./types`). `go build ./...` /
+  `go test ./...` from the root only cover the root module; run the `types` module separately:
+  `cd types && go test ./...`.
+- `GOTOOLCHAIN=auto` auto-downloads the Go version pinned in `go.mod`; no manual Go install needed.
+- Protobuf codegen uses `buf` (`buf generate`, `buf format`); `buf` is not installed by default
+  and is only needed when regenerating proto code.
+- Known pre-existing failures (unrelated to environment): `types` `TestParseNamespace` has two
+  failing subcases referencing the deprecated namespace format removed in commit `be091cf`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section for the authlib dev environment in a Cursor Cloud VM.

Validated during setup:
- `go build ./...` succeeds (root module) and `go test ./...` passes.
- The `types` submodule builds; two `TestParseNamespace` subcases fail — pre-existing failures referencing the deprecated namespace format removed in `be091cf` (unrelated to environment).

## Notable caveats documented
- Multi-module `go.work` workspace: the root `go test ./...` does not cover `types`; run it separately.
- `buf` is required only for proto codegen and is not installed by default.

No application code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf4d408d-9163-46ca-88d1-526a0948b633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf4d408d-9163-46ca-88d1-526a0948b633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

